### PR TITLE
Feat/latest version registry

### DIFF
--- a/packageregistry/npm.go
+++ b/packageregistry/npm.go
@@ -170,6 +170,7 @@ func npmGetPackageDetails(packageName string) (*Package, error) {
 		Description:         npmpkg.Description,
 		SourceRepositoryUrl: sourceGitURL,
 		Versions:            pkgVerions,
+		LatestVersion:       npmpkg.DistTags.Latest,
 		CreatedAt:           npmpkg.Time.Created,
 		UpdatedAt:           npmpkg.Time.Modified,
 		Downloads:           OptionalInt{Value: downloads, Valid: downloads > 0},

--- a/packageregistry/npm_api.go
+++ b/packageregistry/npm_api.go
@@ -13,6 +13,7 @@ type npmPackage struct {
 	Name        string                       `json:"name"`
 	Description string                       `json:"description"`
 	Versions    map[string]npmPackageVersion `json:"versions"`
+	DistTags    npmPackageDistTags           `json:"dist-tags"`
 	Author      npmPackageAuthor             `json:"author"`
 	Repository  npmPackageRepository         `json:"repository"`
 	Maintainers []npmPackageAuthor           `json:"maintainers"`
@@ -22,6 +23,10 @@ type npmPackage struct {
 // Docs: https://github.com/npm/registry/blob/main/docs/REGISTRY-API.md#version
 type npmPackageVersion struct {
 	Version string `json:"version"`
+}
+
+type npmPackageDistTags struct {
+	Latest string `json:"latest"`
 }
 
 // Throught registry docs....

--- a/packageregistry/npm_test.go
+++ b/packageregistry/npm_test.go
@@ -213,3 +213,45 @@ func TestNpmGetPackage(t *testing.T) {
 		})
 	}
 }
+
+func TestNpmGetPackageLatestVersion(t *testing.T) {
+	cases := []struct {
+		pkgName               string
+		expectedError         error
+		expectedLatestVersion string
+	}{
+		{
+			pkgName:               "express",
+			expectedError:         nil,
+			expectedLatestVersion: "5.1.0",
+		},
+		{
+			pkgName:               "sql",
+			expectedLatestVersion: "0.78.0",
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.pkgName, func(t *testing.T) {
+			t.Parallel()
+
+			adapter, err := NewNpmAdapter()
+			if err != nil {
+				t.Fatalf("failed to create package registry npm adapter: %v", err)
+			}
+
+			pd, err := adapter.PackageDiscovery()
+			if err != nil {
+				t.Fatalf("failed to create package discovery client in npm adapter")
+			}
+
+			pkg, err := pd.GetPackage(test.pkgName)
+			if test.expectedError != nil {
+				assert.ErrorIs(t, err, test.expectedError)
+			} else {
+				assert.NoError(t, err)
+				assert.GreaterOrEqual(t, pkg.LatestVersion, test.expectedLatestVersion)
+			}
+		})
+	}
+}

--- a/packageregistry/pypi.go
+++ b/packageregistry/pypi.go
@@ -128,6 +128,7 @@ func (np *pypiPackageDiscovery) GetPackage(packageName string) (*Package, error)
 		SourceRepositoryUrl: sourceGitURL,
 		Author:              author,
 		Maintainers:         maintainers,
+		LatestVersion:       pypipkg.Info.LatestVersion,
 		Versions:            pkgVersions,
 		// Do offical way to get downloads
 		// Thought we can use pypi.tech

--- a/packageregistry/pypi_test.go
+++ b/packageregistry/pypi_test.go
@@ -188,3 +188,44 @@ func TestPypiGetPublisherPackages(t *testing.T) {
 		})
 	}
 }
+
+func TestPypiGetPackageLatestVersion(t *testing.T) {
+	cases := []struct {
+		pkgName               string
+		expectedError         error
+		expectedLatestVersion string
+	}{
+		{
+			pkgName:               "requests",
+			expectedLatestVersion: "2.32.3",
+		},
+		{
+			pkgName:               "fastapi",
+			expectedLatestVersion: "0.115.12",
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.pkgName, func(t *testing.T) {
+			t.Parallel()
+
+			adapter, err := NewPypiAdapter()
+			if err != nil {
+				t.Fatalf("failed to create package registry pypi adapter: %v", err)
+			}
+
+			pd, err := adapter.PackageDiscovery()
+			if err != nil {
+				t.Fatalf("failed to create package discovery client in pypi adapter")
+			}
+
+			pkg, err := pd.GetPackage(test.pkgName)
+			if test.expectedError != nil {
+				assert.ErrorIs(t, err, test.expectedError)
+			} else {
+				assert.NoError(t, err)
+				assert.GreaterOrEqual(t, pkg.LatestVersion, test.expectedLatestVersion)
+			}
+		})
+	}
+}

--- a/packageregistry/registry.go
+++ b/packageregistry/registry.go
@@ -55,6 +55,9 @@ type Package struct {
 	// Maintainers of the package (can include author also)
 	Maintainers []Publisher `json:"maintainers"`
 
+	// Latest version of the package
+	LatestVersion string `json:"latest_version"`
+
 	// Published versions of the project.
 	Versions []PackageVersionInfo `json:"versions"`
 

--- a/packageregistry/ruby.go
+++ b/packageregistry/ruby.go
@@ -145,6 +145,7 @@ func convertGemObjectToPackage(gemObject gemObject) (*Package, error) {
 		Name:                gemObject.Name,
 		Description:         gemObject.Description,
 		SourceRepositoryUrl: sourceGitURL,
+		LatestVersion:       gemObject.LatestVersion,
 		Versions:            pkgVersions,
 		Downloads: OptionalInt{
 			Value: gemObject.TotalDownloads,

--- a/packageregistry/ruby_test.go
+++ b/packageregistry/ruby_test.go
@@ -188,3 +188,44 @@ func TestRubyGetPackage(t *testing.T) {
 		})
 	}
 }
+
+func TestRubyGetPackageLatestVersion(t *testing.T) {
+	cases := []struct {
+		pkgName               string
+		expectedError         error
+		expectedLatestVersion string
+	}{
+		{
+			pkgName:               "rails",
+			expectedLatestVersion: "8.0.2",
+		},
+		{
+			pkgName:               "sql_enum",
+			expectedLatestVersion: "1.0.0",
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.pkgName, func(t *testing.T) {
+			t.Parallel()
+
+			adapter, err := NewRubyAdapter()
+			if err != nil {
+				t.Fatalf("failed to create package registry npm adapter: %v", err)
+			}
+
+			pd, err := adapter.PackageDiscovery()
+			if err != nil {
+				t.Fatalf("failed to create package discovery client in npm adapter")
+			}
+
+			pkg, err := pd.GetPackage(test.pkgName)
+			if test.expectedError != nil {
+				assert.ErrorIs(t, err, test.expectedError)
+			} else {
+				assert.NoError(t, err)
+				assert.GreaterOrEqual(t, pkg.LatestVersion, test.expectedLatestVersion)
+			}
+		})
+	}
+}


### PR DESCRIPTION
fixes #13 

This is required for finding the latest version in vet inspect malware command, every registry as a way (property) in their response, but we didn't used that before, now we are using them for `LatestVersion` property. 
