### PR TITLE
tui: remove color from Info and Success roles

### DIFF
--- a/tui/diff/diff.go
+++ b/tui/diff/diff.go
@@ -46,7 +46,7 @@ func Render(oldText, newText string) string {
 			continue
 		}
 		if hasOld {
-			b.WriteString(styleLine("-"+oldLine, theme.RoleError))
+			b.WriteString(styleLine("-"+oldLine, theme.RoleDiffRemove))
 			b.WriteString("\n")
 		}
 		if hasNew {

--- a/tui/diff/diff.go
+++ b/tui/diff/diff.go
@@ -50,7 +50,7 @@ func Render(oldText, newText string) string {
 			b.WriteString("\n")
 		}
 		if hasNew {
-			b.WriteString(styleLine("+"+newLine, theme.RoleSuccess))
+			b.WriteString(styleLine("+"+newLine, theme.RoleDiffAdd))
 			b.WriteString("\n")
 		}
 	}

--- a/tui/theme/palette.go
+++ b/tui/theme/palette.go
@@ -173,9 +173,11 @@ func (p Palette) WithColorByRole(r Role, c lipgloss.AdaptiveColor) Palette {
 // color literals. A CI grep check enforces this.
 func safeDepPalette() Palette {
 	return Palette{
-		// Semantic — cyan/green/amber/red with readable contrast on both light and dark.
-		Info:    lipgloss.AdaptiveColor{Light: "#0E7490", Dark: "#67E8F9"}, // cyan-700 / cyan-300
-		Success: lipgloss.AdaptiveColor{Light: "#15803D", Dark: "#86EFAC"}, // green-700 / green-300
+		// Semantic — only warnings and errors carry color; info and success use the
+		// terminal's default foreground so routine messages don't compete visually
+		// with actionable ones.
+		Info:    lipgloss.AdaptiveColor{Light: "", Dark: ""},
+		Success: lipgloss.AdaptiveColor{Light: "", Dark: ""},
 		Warning: lipgloss.AdaptiveColor{Light: "#B45309", Dark: "#FCD34D"}, // amber-700 / amber-300
 		Error:   lipgloss.AdaptiveColor{Light: "#B91C1C", Dark: "#FCA5A5"}, // red-700 / red-300
 		Muted:   lipgloss.AdaptiveColor{Light: "#64748B", Dark: "#94A3B8"}, // slate-500 / slate-400

--- a/tui/theme/palette.go
+++ b/tui/theme/palette.go
@@ -17,6 +17,9 @@ type Palette struct {
 	Heading lipgloss.AdaptiveColor
 	Path    lipgloss.AdaptiveColor
 
+	// Diff
+	DiffAdd lipgloss.AdaptiveColor // added lines (+); separate from Success so Success can be uncolored
+
 	// Severity
 	Critical lipgloss.AdaptiveColor
 	High     lipgloss.AdaptiveColor
@@ -53,6 +56,7 @@ const (
 	RoleText
 	RoleHeading
 	RolePath
+	RoleDiffAdd
 	RoleCritical
 	RoleHigh
 	RoleMedium
@@ -87,6 +91,8 @@ func (p Palette) ColorByRole(r Role) (lipgloss.AdaptiveColor, bool) {
 		return p.Heading, true
 	case RolePath:
 		return p.Path, true
+	case RoleDiffAdd:
+		return p.DiffAdd, true
 	case RoleCritical:
 		return p.Critical, true
 	case RoleHigh:
@@ -137,6 +143,8 @@ func (p Palette) WithColorByRole(r Role, c lipgloss.AdaptiveColor) Palette {
 		out.Heading = c
 	case RolePath:
 		out.Path = c
+	case RoleDiffAdd:
+		out.DiffAdd = c
 	case RoleCritical:
 		out.Critical = c
 	case RoleHigh:
@@ -184,6 +192,9 @@ func safeDepPalette() Palette {
 		Text:    lipgloss.AdaptiveColor{Light: "#1F2937", Dark: "#E5E7EB"}, // gray-800 / gray-200
 		Heading: lipgloss.AdaptiveColor{Light: "#111827", Dark: "#F3F4F6"}, // gray-900 / gray-100
 		Path:    lipgloss.AdaptiveColor{Light: "#1D4ED8", Dark: "#93C5FD"}, // blue-700 / blue-300
+
+		// Diff — green for additions (functional color, not decorative).
+		DiffAdd: lipgloss.AdaptiveColor{Light: "#15803D", Dark: "#86EFAC"}, // green-700 / green-300
 
 		// Severity — deeper tones on light, brighter on dark.
 		Critical: lipgloss.AdaptiveColor{Light: "#991B1B", Dark: "#F87171"}, // red-800 / red-400

--- a/tui/theme/palette.go
+++ b/tui/theme/palette.go
@@ -17,8 +17,10 @@ type Palette struct {
 	Heading lipgloss.AdaptiveColor
 	Path    lipgloss.AdaptiveColor
 
-	// Diff
-	DiffAdd lipgloss.AdaptiveColor // added lines (+); separate from Success so Success can be uncolored
+	// Diff — functional colors for unified diff output; kept separate from
+	// semantic roles so Success/Error can evolve independently.
+	DiffAdd    lipgloss.AdaptiveColor // added lines (+)
+	DiffRemove lipgloss.AdaptiveColor // removed lines (-)
 
 	// Severity
 	Critical lipgloss.AdaptiveColor
@@ -57,6 +59,7 @@ const (
 	RoleHeading
 	RolePath
 	RoleDiffAdd
+	RoleDiffRemove
 	RoleCritical
 	RoleHigh
 	RoleMedium
@@ -93,6 +96,8 @@ func (p Palette) ColorByRole(r Role) (lipgloss.AdaptiveColor, bool) {
 		return p.Path, true
 	case RoleDiffAdd:
 		return p.DiffAdd, true
+	case RoleDiffRemove:
+		return p.DiffRemove, true
 	case RoleCritical:
 		return p.Critical, true
 	case RoleHigh:
@@ -145,6 +150,8 @@ func (p Palette) WithColorByRole(r Role, c lipgloss.AdaptiveColor) Palette {
 		out.Path = c
 	case RoleDiffAdd:
 		out.DiffAdd = c
+	case RoleDiffRemove:
+		out.DiffRemove = c
 	case RoleCritical:
 		out.Critical = c
 	case RoleHigh:
@@ -193,8 +200,9 @@ func safeDepPalette() Palette {
 		Heading: lipgloss.AdaptiveColor{Light: "#111827", Dark: "#F3F4F6"}, // gray-900 / gray-100
 		Path:    lipgloss.AdaptiveColor{Light: "#1D4ED8", Dark: "#93C5FD"}, // blue-700 / blue-300
 
-		// Diff — green for additions (functional color, not decorative).
-		DiffAdd: lipgloss.AdaptiveColor{Light: "#15803D", Dark: "#86EFAC"}, // green-700 / green-300
+		// Diff — functional red/green for unified diff output.
+		DiffAdd:    lipgloss.AdaptiveColor{Light: "#15803D", Dark: "#86EFAC"}, // green-700 / green-300
+		DiffRemove: lipgloss.AdaptiveColor{Light: "#B91C1C", Dark: "#FCA5A5"}, // red-700 / red-300
 
 		// Severity — deeper tones on light, brighter on dark.
 		Critical: lipgloss.AdaptiveColor{Light: "#991B1B", Dark: "#F87171"}, // red-800 / red-400

--- a/tui/theme/palette_test.go
+++ b/tui/theme/palette_test.go
@@ -9,11 +9,12 @@ import (
 
 func TestSafeDepPaletteNonEmpty(t *testing.T) {
 	p := safeDepPalette()
-	// Spot-check that all required fields are populated. We assert on the
-	// Dark half of each AdaptiveColor; Light is exercised by integration
-	// tests that force --light mode.
-	assert.NotEmpty(t, p.Info.Dark)
-	assert.NotEmpty(t, p.Success.Dark)
+	// Info and Success intentionally have no color — they use the terminal's
+	// default foreground so routine messages don't compete with actionable ones.
+	assert.Empty(t, p.Info.Dark)
+	assert.Empty(t, p.Success.Dark)
+
+	// Actionable roles must always carry color.
 	assert.NotEmpty(t, p.Warning.Dark)
 	assert.NotEmpty(t, p.Error.Dark)
 	assert.NotEmpty(t, p.Muted.Dark)


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/safedep/dry/pull/113" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
