### PR TITLE
fix failing crates.io and huggingface e2e tests

### DIFF
--- a/adapters/huggingface/huggingface_test.go
+++ b/adapters/huggingface/huggingface_test.go
@@ -357,9 +357,11 @@ func TestHuggingFaceHubClient_GetModel_E2E(t *testing.T) {
 				assert.NotEmpty(t, model.CreatedAt)
 				assert.NotEmpty(t, model.LastModified)
 
-				// Validate complex fields
+				// Validate complex fields. transformersInfo is optional and its
+				// individual keys (e.g. pipeline_tag) vary per model over time, so
+				// only assert that it is populated when present.
 				if model.TransformersInfo != nil {
-					assert.NotEmpty(t, model.TransformersInfo["pipeline_tag"])
+					assert.NotEmpty(t, model.TransformersInfo)
 				}
 			},
 		},

--- a/packageregistry/protocol.go
+++ b/packageregistry/protocol.go
@@ -5,11 +5,32 @@ import (
 	"time"
 )
 
+// userAgent identifies our client to package registries. Some registries
+// (e.g. crates.io) reject requests using the default Go user-agent with a
+// 403, so we set a descriptive one that links back to the project.
+const userAgent = "safedep-dry (https://github.com/safedep/dry)"
+
+// userAgentTransport sets a User-Agent header on every request that does not
+// already carry one.
+type userAgentTransport struct {
+	base http.RoundTripper
+}
+
+func (t *userAgentTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Header.Get("User-Agent") == "" {
+		// Clone to avoid mutating a request the caller may reuse.
+		req = req.Clone(req.Context())
+		req.Header.Set("User-Agent", userAgent)
+	}
+	return t.base.RoundTrip(req)
+}
+
 // httpClient returns a new http.Client with our opinionated
 // defaults. If required, we need to implement a package specific
 // configuration / fine tuning.
 func httpClient() *http.Client {
 	return &http.Client{
-		Timeout: 10 * time.Second,
+		Timeout:   10 * time.Second,
+		Transport: &userAgentTransport{base: http.DefaultTransport},
 	}
 }


### PR DESCRIPTION
crates.io now rejects the default Go user-agent with a 403, so set a descriptive User-Agent on the package registry HTTP client.

The Llama-4-Scout model's transformersInfo no longer includes a pipeline_tag key; assert the map is populated instead of that key.