### PR TITLE
feat(events/inbox): add WithLeader advisory-lock election to the S2 source

### DIFF
--- a/events/inbox/sources/leader.go
+++ b/events/inbox/sources/leader.go
@@ -1,0 +1,127 @@
+package sources
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"hash/fnv"
+	"time"
+
+	"github.com/safedep/dry/db"
+	"github.com/safedep/dry/log"
+)
+
+const (
+	leaderRetryInterval = 5 * time.Second
+	// leaderPingInterval throttles the liveness check on the held lock connection,
+	// bounding the split-brain window if the connection dies silently.
+	leaderPingInterval = 5 * time.Second
+)
+
+// advisoryLeader gates an S2 source so only one replica reads a feed — the
+// single-active-consumer invariant the client-side cursor requires. It holds a
+// Postgres session advisory lock on a dedicated connection: holding the
+// connection holds the lock, and losing it (crash / network) releases it so a
+// standby takes over. Mirrors the outbox drain leader.
+type advisoryLeader struct {
+	sqlDB *sql.DB
+	key   int64
+
+	conn     *sql.Conn // non-nil while this instance holds leadership
+	lastPing time.Time
+}
+
+func newAdvisoryLeader(adapter db.SqlDataAdapter, key int64) (*advisoryLeader, error) {
+	gdb, err := adapter.GetDB()
+	if err != nil {
+		return nil, err
+	}
+	if name := gdb.Dialector.Name(); name != "postgres" {
+		return nil, fmt.Errorf("inbox/s2: leader election requires PostgreSQL, got %q", name)
+	}
+	sqlDB, err := adapter.GetConn()
+	if err != nil {
+		return nil, err
+	}
+	return &advisoryLeader{sqlDB: sqlDB, key: key}, nil
+}
+
+// leaderKey derives the advisory-lock key from the cursor identity, so each
+// (consumer_name, feed) elects independently and two feeds under one consumer
+// name are not serialized behind a single lock.
+func leaderKey(consumerName, feed string) int64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(consumerName + "\x00" + feed))
+	return int64(h.Sum64())
+}
+
+// ensureLeading guarantees this instance holds leadership before returning, or
+// returns ctx's error. reacquired is true when leadership was freshly taken
+// (first acquisition, or after a lost lock) — the caller reopens its read session
+// so it resumes from the persisted cursor under the new leadership rather than
+// continuing a session opened by (or concurrent with) a former leader.
+func (l *advisoryLeader) ensureLeading(ctx context.Context) (reacquired bool, err error) {
+	if l.conn != nil {
+		if time.Since(l.lastPing) < leaderPingInterval {
+			return false, nil
+		}
+		if pingErr := l.conn.PingContext(ctx); pingErr == nil {
+			l.lastPing = time.Now()
+			return false, nil
+		}
+		log.Warnf("inbox/s2: lost feed leadership; re-acquiring")
+		l.release()
+	}
+
+	for {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return false, ctxErr
+		}
+		acquired, acqErr := l.tryAcquire(ctx)
+		if acqErr != nil {
+			return false, acqErr
+		}
+		if acquired {
+			log.Infof("inbox/s2: acquired feed leadership")
+			return true, nil
+		}
+		// Another replica leads; idle and retry so we fail over when it dies.
+		select {
+		case <-ctx.Done():
+			return false, ctx.Err()
+		case <-time.After(leaderRetryInterval):
+		}
+	}
+}
+
+func (l *advisoryLeader) tryAcquire(ctx context.Context) (bool, error) {
+	conn, err := l.sqlDB.Conn(ctx)
+	if err != nil {
+		return false, fmt.Errorf("acquire connection: %w", err)
+	}
+
+	var acquired bool
+	if err := conn.QueryRowContext(ctx, "SELECT pg_try_advisory_lock($1)", l.key).Scan(&acquired); err != nil {
+		_ = conn.Close()
+		return false, fmt.Errorf("advisory lock: %w", err)
+	}
+	if !acquired {
+		_ = conn.Close() // returns the connection to the pool, holding no lock
+		return false, nil
+	}
+
+	l.conn = conn
+	l.lastPing = time.Now()
+	return true, nil
+}
+
+// release unlocks and returns the held connection to the pool. Uses a background
+// context so the unlock runs even when the caller's context is already cancelled.
+func (l *advisoryLeader) release() {
+	if l.conn == nil {
+		return
+	}
+	_, _ = l.conn.ExecContext(context.Background(), "SELECT pg_advisory_unlock($1)", l.key)
+	_ = l.conn.Close()
+	l.conn = nil
+}

--- a/events/inbox/sources/leader.go
+++ b/events/inbox/sources/leader.go
@@ -63,6 +63,14 @@ func leaderKey(consumerName, feed string) int64 {
 	return int64(h.Sum64())
 }
 
+// closeLockConn returns a lock connection to the pool, logging an unexpected
+// close failure rather than swallowing it.
+func closeLockConn(conn *sql.Conn) {
+	if err := conn.Close(); err != nil {
+		log.Warnf("inbox/s2: close lock connection: %v", err)
+	}
+}
+
 // ensureLeading blocks until this instance holds leadership, returning the term
 // context — alive while it leads, cancelled the moment leadership is lost (the
 // lock connection drops) or baseCtx is done. The read session MUST be opened with
@@ -106,11 +114,11 @@ func (l *advisoryLeader) tryAcquire(baseCtx context.Context) (context.Context, b
 
 	var acquired bool
 	if err := conn.QueryRowContext(baseCtx, "SELECT pg_try_advisory_lock($1)", l.key).Scan(&acquired); err != nil {
-		_ = conn.Close()
+		closeLockConn(conn)
 		return nil, false, fmt.Errorf("advisory lock: %w", err)
 	}
 	if !acquired {
-		_ = conn.Close() // returns the connection to the pool, holding no lock
+		closeLockConn(conn) // returns the connection to the pool, holding no lock
 		return nil, false, nil
 	}
 
@@ -155,8 +163,11 @@ func (l *advisoryLeader) hold(conn *sql.Conn, leadCtx context.Context, cancel co
 // term ended via cancellation.
 func (l *advisoryLeader) release(conn *sql.Conn, cancel context.CancelFunc) {
 	cancel()
-	_, _ = conn.ExecContext(context.Background(), "SELECT pg_advisory_unlock($1)", l.key)
-	_ = conn.Close()
+	if _, err := conn.ExecContext(context.Background(), "SELECT pg_advisory_unlock($1)", l.key); err != nil {
+		// Non-fatal: closing the connection below releases the session lock anyway.
+		log.Warnf("inbox/s2: advisory unlock: %v", err)
+	}
+	closeLockConn(conn)
 
 	l.mu.Lock()
 	if l.conn == conn {

--- a/events/inbox/sources/leader.go
+++ b/events/inbox/sources/leader.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"hash/fnv"
+	"sync"
 	"time"
 
 	"github.com/safedep/dry/db"
@@ -23,12 +24,19 @@ const (
 // Postgres session advisory lock on a dedicated connection: holding the
 // connection holds the lock, and losing it (crash / network) releases it so a
 // standby takes over. Mirrors the outbox drain leader.
+//
+// A leadership term has its own context, cancelled the moment the term ends. The
+// read session is opened with it, so a read blocked in Next() unwinds immediately
+// when leadership is lost — without that, a former leader's session would keep
+// returning records alongside the new leader's and both would advance the cursor.
 type advisoryLeader struct {
 	sqlDB *sql.DB
 	key   int64
 
-	conn     *sql.Conn // non-nil while this instance holds leadership
-	lastPing time.Time
+	mu      sync.Mutex
+	conn    *sql.Conn // non-nil while this instance holds leadership
+	leadCtx context.Context
+	cancel  context.CancelFunc
 }
 
 func newAdvisoryLeader(adapter db.SqlDataAdapter, key int64) (*advisoryLeader, error) {
@@ -55,73 +63,106 @@ func leaderKey(consumerName, feed string) int64 {
 	return int64(h.Sum64())
 }
 
-// ensureLeading guarantees this instance holds leadership before returning, or
-// returns ctx's error. reacquired is true when leadership was freshly taken
-// (first acquisition, or after a lost lock) — the caller reopens its read session
-// so it resumes from the persisted cursor under the new leadership rather than
-// continuing a session opened by (or concurrent with) a former leader.
-func (l *advisoryLeader) ensureLeading(ctx context.Context) (reacquired bool, err error) {
-	if l.conn != nil {
-		if time.Since(l.lastPing) < leaderPingInterval {
-			return false, nil
-		}
-		if pingErr := l.conn.PingContext(ctx); pingErr == nil {
-			l.lastPing = time.Now()
-			return false, nil
-		}
-		log.Warnf("inbox/s2: lost feed leadership; re-acquiring")
-		l.release()
+// ensureLeading blocks until this instance holds leadership, returning the term
+// context — alive while it leads, cancelled the moment leadership is lost (the
+// lock connection drops) or baseCtx is done. The read session MUST be opened with
+// it (§ the type doc). reacquired is true on a fresh term so the caller reopens
+// its session under the new context, resuming from the persisted cursor.
+func (l *advisoryLeader) ensureLeading(baseCtx context.Context) (leadCtx context.Context, reacquired bool, err error) {
+	l.mu.Lock()
+	if l.leadCtx != nil && l.leadCtx.Err() == nil {
+		current := l.leadCtx
+		l.mu.Unlock()
+		return current, false, nil
 	}
+	l.mu.Unlock()
 
 	for {
-		if ctxErr := ctx.Err(); ctxErr != nil {
-			return false, ctxErr
+		if err := baseCtx.Err(); err != nil {
+			return nil, false, err
 		}
-		acquired, acqErr := l.tryAcquire(ctx)
-		if acqErr != nil {
-			return false, acqErr
+		ctx, acquired, err := l.tryAcquire(baseCtx)
+		if err != nil {
+			return nil, false, err
 		}
 		if acquired {
 			log.Infof("inbox/s2: acquired feed leadership")
-			return true, nil
+			return ctx, true, nil
 		}
 		// Another replica leads; idle and retry so we fail over when it dies.
 		select {
-		case <-ctx.Done():
-			return false, ctx.Err()
+		case <-baseCtx.Done():
+			return nil, false, baseCtx.Err()
 		case <-time.After(leaderRetryInterval):
 		}
 	}
 }
 
-func (l *advisoryLeader) tryAcquire(ctx context.Context) (bool, error) {
-	conn, err := l.sqlDB.Conn(ctx)
+func (l *advisoryLeader) tryAcquire(baseCtx context.Context) (context.Context, bool, error) {
+	conn, err := l.sqlDB.Conn(baseCtx)
 	if err != nil {
-		return false, fmt.Errorf("acquire connection: %w", err)
+		return nil, false, fmt.Errorf("acquire connection: %w", err)
 	}
 
 	var acquired bool
-	if err := conn.QueryRowContext(ctx, "SELECT pg_try_advisory_lock($1)", l.key).Scan(&acquired); err != nil {
+	if err := conn.QueryRowContext(baseCtx, "SELECT pg_try_advisory_lock($1)", l.key).Scan(&acquired); err != nil {
 		_ = conn.Close()
-		return false, fmt.Errorf("advisory lock: %w", err)
+		return nil, false, fmt.Errorf("advisory lock: %w", err)
 	}
 	if !acquired {
 		_ = conn.Close() // returns the connection to the pool, holding no lock
-		return false, nil
+		return nil, false, nil
 	}
 
+	leadCtx, cancel := context.WithCancel(baseCtx)
+	l.mu.Lock()
 	l.conn = conn
-	l.lastPing = time.Now()
-	return true, nil
+	l.leadCtx = leadCtx
+	l.cancel = cancel
+	l.mu.Unlock()
+
+	go l.hold(conn, leadCtx, cancel)
+	return leadCtx, true, nil
 }
 
-// release unlocks and returns the held connection to the pool. Uses a background
-// context so the unlock runs even when the caller's context is already cancelled.
-func (l *advisoryLeader) release() {
-	if l.conn == nil {
-		return
+// hold owns a leadership term: it pings the lock connection until the ping fails
+// (the lock is gone) or leadCtx is cancelled (baseCtx / graceful stop), then
+// releases the lock exactly once. Running release here — not in the read path —
+// frees the lock promptly on a graceful stop even though Source has no Close hook.
+func (l *advisoryLeader) hold(conn *sql.Conn, leadCtx context.Context, cancel context.CancelFunc) {
+	ticker := time.NewTicker(leaderPingInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-leadCtx.Done():
+			l.release(conn, cancel)
+			return
+		case <-ticker.C:
+			if err := conn.PingContext(leadCtx); err != nil {
+				if leadCtx.Err() == nil {
+					log.Warnf("inbox/s2: lost feed leadership: %v", err)
+				}
+				l.release(conn, cancel)
+				return
+			}
+		}
 	}
-	_, _ = l.conn.ExecContext(context.Background(), "SELECT pg_advisory_unlock($1)", l.key)
-	_ = l.conn.Close()
-	l.conn = nil
+}
+
+// release cancels the term (unblocking the read), unlocks, and returns the
+// connection to the pool. Background context so the unlock runs even when the
+// term ended via cancellation.
+func (l *advisoryLeader) release(conn *sql.Conn, cancel context.CancelFunc) {
+	cancel()
+	_, _ = conn.ExecContext(context.Background(), "SELECT pg_advisory_unlock($1)", l.key)
+	_ = conn.Close()
+
+	l.mu.Lock()
+	if l.conn == conn {
+		l.conn = nil
+		l.leadCtx = nil
+		l.cancel = nil
+	}
+	l.mu.Unlock()
 }

--- a/events/inbox/sources/leader_test.go
+++ b/events/inbox/sources/leader_test.go
@@ -1,0 +1,66 @@
+package sources
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/safedep/dry/db"
+	"github.com/safedep/dry/stream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// sqliteAdapter is a minimal SqlDataAdapter over sqlite — enough to exercise the
+// "leader election requires PostgreSQL" guard. The live advisory-lock path needs
+// a real Postgres and is covered by integration tests.
+type sqliteAdapter struct{ gdb *gorm.DB }
+
+func (a sqliteAdapter) GetDB() (*gorm.DB, error)            { return a.gdb, nil }
+func (a sqliteAdapter) GetConn() (*sql.DB, error)           { return a.gdb.DB() }
+func (a sqliteAdapter) Migrate(models ...interface{}) error { return a.gdb.AutoMigrate(models...) }
+func (a sqliteAdapter) Ping() error {
+	conn, err := a.gdb.DB()
+	if err != nil {
+		return err
+	}
+	return conn.Ping()
+}
+
+func newSqliteAdapter(t *testing.T) db.SqlDataAdapter {
+	t.Helper()
+	gdb, err := gorm.Open(sqlite.Open(filepath.Join(t.TempDir(), "leader.db")), &gorm.Config{})
+	require.NoError(t, err)
+	return sqliteAdapter{gdb: gdb}
+}
+
+func TestLeaderKey(t *testing.T) {
+	// Deterministic, and distinct per (consumer, feed) so feeds don't share a lock.
+	assert.Equal(t, leaderKey("c", "f"), leaderKey("c", "f"))
+	assert.NotEqual(t, leaderKey("c", "f1"), leaderKey("c", "f2"))
+	assert.NotEqual(t, leaderKey("c1", "f"), leaderKey("c2", "f"))
+	// The separator prevents (c+f) collisions across the boundary.
+	assert.NotEqual(t, leaderKey("ab", "c"), leaderKey("a", "bc"))
+}
+
+func TestNewAdvisoryLeader_RequiresPostgres(t *testing.T) {
+	_, err := newAdvisoryLeader(newSqliteAdapter(t), leaderKey("c", "f"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "PostgreSQL")
+}
+
+func TestNewS2_WithLeaderRequiresPostgres(t *testing.T) {
+	_, err := NewS2(stream.StreamFor(routingX()), stream.S2StreamProviderConfig{ApiKey: "k"},
+		nil, newMemCursors(), "consumer-a", WithLeader(newSqliteAdapter(t)))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "PostgreSQL")
+}
+
+func TestNewS2_NoLeaderByDefault(t *testing.T) {
+	src, err := NewS2(stream.StreamFor(routingX()), stream.S2StreamProviderConfig{ApiKey: "k"},
+		nil, newMemCursors(), "consumer-a")
+	require.NoError(t, err)
+	assert.Nil(t, src.(*s2Source).leader)
+}

--- a/events/inbox/sources/s2.go
+++ b/events/inbox/sources/s2.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/safedep/dry/db"
 	"github.com/safedep/dry/events/inbox"
 	"github.com/safedep/dry/log"
 	"github.com/safedep/dry/stream"
@@ -35,9 +36,30 @@ type s2Source struct {
 	// newSession opens a read session at a position. Defaults to the real S2 read
 	// session; tests inject a fake to exercise reopen/stall/cursor logic offline.
 	newSession func(ctx context.Context, startPosition string) (stream.StreamReadSession, error)
+
+	// leader, when set (WithLeader), gates reading so only one replica consumes
+	// the feed — required because the S2 cursor is client-side and two readers
+	// would clobber it. Nil for single-replica deployments.
+	leader *advisoryLeader
+
+	// leaderAdapter is staged by WithLeader and consumed by NewS2 once the cursor
+	// key (consumer + feed) is known, then discarded.
+	leaderAdapter db.SqlDataAdapter
 }
 
 var _ inbox.Source = &s2Source{}
+
+// S2Option configures an S2 inbox Source.
+type S2Option func(*s2Source)
+
+// WithLeader makes the source safe to run on every replica: only the holder of a
+// Postgres advisory lock (keyed on the consumer + feed) actually reads; the rest
+// idle and take over if it dies. Requires a PostgreSQL adapter — NewS2 errors
+// otherwise. Omit it for single-replica deployments (S2's server side does not
+// elect for us, unlike a NATS durable consumer).
+func WithLeader(adapter db.SqlDataAdapter) S2Option {
+	return func(s *s2Source) { s.leaderAdapter = adapter }
+}
 
 // NewS2 builds an S2 inbox Source for one event feed. The caller resolves the
 // stream identity — stream.StreamFor(routing) for a global feed, or
@@ -51,7 +73,7 @@ var _ inbox.Source = &s2Source{}
 // and identifies this consumer in stalled-cursor diagnostics. A nil basinResolver
 // uses the default.
 func NewS2(feedStream stream.Stream, config stream.S2StreamProviderConfig,
-	basinResolver stream.S2BasinResolver, cursors inbox.CursorStore, consumerName string) (inbox.Source, error) {
+	basinResolver stream.S2BasinResolver, cursors inbox.CursorStore, consumerName string, opts ...S2Option) (inbox.Source, error) {
 
 	if config.ApiKey == "" {
 		return nil, fmt.Errorf("inbox/s2: S2 API key is not set")
@@ -80,6 +102,17 @@ func NewS2(feedStream stream.Stream, config stream.S2StreamProviderConfig,
 		consumerName:  consumerName,
 		feed:          feed,
 	}
+	for _, opt := range opts {
+		opt(src)
+	}
+	if src.leaderAdapter != nil {
+		leader, err := newAdvisoryLeader(src.leaderAdapter, leaderKey(consumerName, feed))
+		if err != nil {
+			return nil, err
+		}
+		src.leader = leader
+		src.leaderAdapter = nil
+	}
 	src.newSession = func(ctx context.Context, startPosition string) (stream.StreamReadSession, error) {
 		return stream.NewS2StreamReadSession(ctx, src.config, src.basinResolver, src.stream,
 			stream.StreamReadOptions{StartPosition: startPosition})
@@ -88,6 +121,19 @@ func NewS2(feedStream stream.Stream, config stream.S2StreamProviderConfig,
 }
 
 func (s *s2Source) Receive(ctx context.Context) (*inbox.Delivery, error) {
+	if s.leader != nil {
+		// Block until we hold leadership. A standby parks here until the current
+		// leader dies; a fresh acquisition (reacquired) means another replica may
+		// have advanced the cursor, so drop our session and resume from it.
+		reacquired, err := s.leader.ensureLeading(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if reacquired {
+			s.closeSession()
+		}
+	}
+
 	if s.session == nil {
 		if err := s.reopen(ctx); err != nil {
 			return nil, err

--- a/events/inbox/sources/s2.go
+++ b/events/inbox/sources/s2.go
@@ -121,37 +121,52 @@ func NewS2(feedStream stream.Stream, config stream.S2StreamProviderConfig,
 }
 
 func (s *s2Source) Receive(ctx context.Context) (*inbox.Delivery, error) {
+	// readCtx is the context the read session is bound to. With a leader it is the
+	// leadership-term context, so a read blocked in Next() unwinds the instant
+	// leadership is lost (preventing a former leader from reading alongside a new
+	// one). Without a leader it is just the consumer's context.
+	readCtx := ctx
 	if s.leader != nil {
 		// Block until we hold leadership. A standby parks here until the current
 		// leader dies; a fresh acquisition (reacquired) means another replica may
 		// have advanced the cursor, so drop our session and resume from it.
-		reacquired, err := s.leader.ensureLeading(ctx)
+		leadCtx, reacquired, err := s.leader.ensureLeading(ctx)
 		if err != nil {
 			return nil, err
 		}
 		if reacquired {
 			s.closeSession()
 		}
+		readCtx = leadCtx
 	}
 
 	if s.session == nil {
-		if err := s.reopen(ctx); err != nil {
+		if err := s.reopen(readCtx); err != nil {
 			return nil, err
 		}
 	}
 
 	rec, err := s.session.Next()
 	if err != nil {
-		// io.EOF, a transport error, or ctx done: drop the session so the next
-		// Receive reopens at the persisted cursor. Consume returns on ctx errors
-		// and backs off + retries on the rest.
+		// Drop the session so the next Receive reopens at the persisted cursor.
 		s.closeSession()
-		return nil, err
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr // the consumer's own context ended → terminal
+		}
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			// The lease context (not the consumer's) was cancelled: leadership was
+			// lost mid-read. Surface a non-terminal error so Consume backs off and
+			// the next Receive re-acquires leadership and reopens at the cursor.
+			return nil, errLeadershipLost
+		}
+		return nil, err // io.EOF / transport error: Consume backs off and retries
 	}
 
 	return &inbox.Delivery{
 		Payload: rec.Body,
-		Ack:     func() error { return s.ack(ctx, rec.Next) },
+		// Advance under readCtx so a cursor write by a former leader fails once its
+		// lease is cancelled, rather than racing the new leader's advance.
+		Ack: func() error { return s.ack(readCtx, rec.Next) },
 		Nack: func() error {
 			// Tear down so the next Receive reopens at the (un-advanced) cursor,
 			// redelivering this record and everything after it.
@@ -160,6 +175,11 @@ func (s *s2Source) Receive(ctx context.Context) (*inbox.Delivery, error) {
 		},
 	}, nil
 }
+
+// errLeadershipLost signals that the read stopped because this replica lost
+// leadership (its lease context was cancelled) while the consumer is still
+// running. It is non-terminal: Consume backs off and re-acquires.
+var errLeadershipLost = errors.New("inbox/s2: leadership lost")
 
 // reopen loads the persisted cursor and opens a fresh read session there, warning
 // when consecutive reopens land on the same position (a stalled/poison record).


### PR DESCRIPTION
## Summary

Follow-up to #124. Adds the deferred **single-active leader election** to the inbox S2 source (spec §6.3/§7), so a consumer is safe to run on every replica.

S2 has **no server-side single-active election** (unlike a NATS JetStream durable consumer), and the inbox cursor is **client-side** — two replicas reading one feed would clobber the shared cursor row. `WithLeader` closes that gap.

## What it does

- `sources.WithLeader(adapter db.SqlDataAdapter)` — an option on `NewS2`. When set, only the holder of a **Postgres session advisory lock** actually reads; standbys park in `Receive` and take over when the leader's connection dies (which releases the lock). Mirrors the outbox drain leader (`pg_try_advisory_lock` on a dedicated connection).
- **Lock key = `(consumer_name, feed)`** (fnv64 of the cursor identity), matching the cursor's granularity — so two feeds under one consumer name elect independently rather than serializing behind a single lock.
- **Failover correctness:** a fresh acquisition (`reacquired`) drops the read session, so the new leader resumes from the *persisted cursor* rather than a stale or concurrent position. A throttled liveness ping bounds the split-brain window if the held connection dies silently.
- Requires PostgreSQL — `NewS2` errors otherwise (same guard as the outbox).

## Why now

The first real malysis consumer on this inbox is the threat-monitor migration (sunsetting the legacy `monitor-package-versions` raw stream), which runs replicated across pods. It needs single-active S2 consumption, so the leader moves from "deferred follow-up" to "needed next." Putting it in the inbox keeps the election in the canonical consumer abstraction instead of each consumer re-implementing it.

## Testing

- Unit: lock-key determinism/distinctness, the requires-PostgreSQL guard (via sqlite), option wiring, and no-leader-by-default. The live advisory-lock acquire/failover path needs a real Postgres and is left to integration (same approach as the outbox leader).
- `go build`, `go vet`, `go test ./events/inbox/...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018EeQr2DxAQAPfzNJnuja7W)_