### PR TITLE
feat(events/inbox): add WithBootstrapFromTail to the S2 source

### DIFF
--- a/events/inbox/sources/s2.go
+++ b/events/inbox/sources/s2.go
@@ -51,6 +51,12 @@ type s2Source struct {
 	// rather than the start of the stream. Only the bootstrap is affected; once a
 	// cursor is persisted, resume is always from it.
 	bootstrapFromTail bool
+
+	// tailResolvedPosition is the position of the first record read during a
+	// from-tail bootstrap, before any ack has persisted a cursor. A pre-ack reopen
+	// (Nack / leadership / transport loss) resumes here instead of re-tailing, so
+	// the unacked record is redelivered rather than skipped. Cleared once acked.
+	tailResolvedPosition string
 }
 
 var _ inbox.Source = &s2Source{}
@@ -175,6 +181,11 @@ func (s *s2Source) Receive(ctx context.Context) (*inbox.Delivery, error) {
 		return nil, err // io.EOF / transport error: Consume backs off and retries
 	}
 
+	// Remember the read position so a from-tail bootstrap that fails before its
+	// first ack reopens here (redelivering) instead of re-tailing past it. Harmless
+	// once a cursor exists — the persisted cursor takes precedence in reopen.
+	s.tailResolvedPosition = rec.Position
+
 	return &inbox.Delivery{
 		Payload: rec.Body,
 		// Advance under readCtx so a cursor write by a former leader fails once its
@@ -201,25 +212,37 @@ func (s *s2Source) reopen(ctx context.Context) error {
 	if err != nil && !errors.Is(err, inbox.ErrNoCursor) {
 		return err
 	}
-	// ErrNoCursor leaves position == "" — the bootstrap signal. By default an
-	// empty StartPosition reads from the beginning; WithBootstrapFromTail instead
-	// starts at the live tail. Either way, once a cursor exists position is
-	// non-empty and resume is from it.
-	readOpts := stream.StreamReadOptions{StartPosition: position}
-	if position == "" && s.bootstrapFromTail {
+
+	// Pick the read start. A persisted cursor always wins. With no cursor yet:
+	// from-tail bootstrap reads the live tail until it has read a record, then
+	// resumes at that record (so a pre-ack failure redelivers it, not skips it);
+	// otherwise read from the beginning.
+	var readOpts stream.StreamReadOptions
+	switch {
+	case position != "":
+		readOpts = stream.StreamReadOptions{StartPosition: position}
+	case s.bootstrapFromTail && s.tailResolvedPosition != "":
+		readOpts = stream.StreamReadOptions{StartPosition: s.tailResolvedPosition}
+	case s.bootstrapFromTail:
 		readOpts = stream.StreamReadOptions{FromTail: true}
+	default:
+		readOpts = stream.StreamReadOptions{StartPosition: ""}
 	}
 
-	if position == s.lastOpenPosition {
-		s.redeliverAttempts++
-	} else {
-		s.lastOpenPosition = position
-		s.redeliverAttempts = 1
-	}
-	if s.redeliverAttempts > 1 {
-		log.Warnf("inbox/s2: stalled cursor consumer=%s feed=%s position=%q attempts=%d "+
-			"(a record is repeatedly failing and blocking the feed; wire WithErrorHandler->Skip or a DLQ)",
-			s.consumerName, s.feed, position, s.redeliverAttempts)
+	// Stall detection on a concrete position only — the tail is a moving target,
+	// so repeated FromTail opens aren't a stalled record.
+	if !readOpts.FromTail {
+		if readOpts.StartPosition == s.lastOpenPosition {
+			s.redeliverAttempts++
+		} else {
+			s.lastOpenPosition = readOpts.StartPosition
+			s.redeliverAttempts = 1
+		}
+		if s.redeliverAttempts > 1 {
+			log.Warnf("inbox/s2: stalled cursor consumer=%s feed=%s position=%q attempts=%d "+
+				"(a record is repeatedly failing and blocking the feed; wire WithErrorHandler->Skip or a DLQ)",
+				s.consumerName, s.feed, readOpts.StartPosition, s.redeliverAttempts)
+		}
 	}
 
 	session, err := s.newSession(ctx, readOpts)
@@ -237,6 +260,8 @@ func (s *s2Source) ack(ctx context.Context, nextPosition string) error {
 		s.closeSession()
 		return err
 	}
+	// The cursor now governs resume; the bootstrap fallback is no longer needed.
+	s.tailResolvedPosition = ""
 	return nil
 }
 

--- a/events/inbox/sources/s2.go
+++ b/events/inbox/sources/s2.go
@@ -33,9 +33,10 @@ type s2Source struct {
 	lastOpenPosition  string
 	redeliverAttempts int
 
-	// newSession opens a read session at a position. Defaults to the real S2 read
-	// session; tests inject a fake to exercise reopen/stall/cursor logic offline.
-	newSession func(ctx context.Context, startPosition string) (stream.StreamReadSession, error)
+	// newSession opens a read session at the given options. Defaults to the real
+	// S2 read session; tests inject a fake to exercise reopen/stall/cursor logic
+	// offline.
+	newSession func(ctx context.Context, opts stream.StreamReadOptions) (stream.StreamReadSession, error)
 
 	// leader, when set (WithLeader), gates reading so only one replica consumes
 	// the feed — required because the S2 cursor is client-side and two readers
@@ -45,6 +46,11 @@ type s2Source struct {
 	// leaderAdapter is staged by WithLeader and consumed by NewS2 once the cursor
 	// key (consumer + feed) is known, then discarded.
 	leaderAdapter db.SqlDataAdapter
+
+	// bootstrapFromTail starts the first read (no cursor yet) at the live tail
+	// rather than the start of the stream. Only the bootstrap is affected; once a
+	// cursor is persisted, resume is always from it.
+	bootstrapFromTail bool
 }
 
 var _ inbox.Source = &s2Source{}
@@ -59,6 +65,14 @@ type S2Option func(*s2Source)
 // elect for us, unlike a NATS durable consumer).
 func WithLeader(adapter db.SqlDataAdapter) S2Option {
 	return func(s *s2Source) { s.leaderAdapter = adapter }
+}
+
+// WithBootstrapFromTail starts a brand-new consumer (no persisted cursor) at the
+// live tail of the feed instead of replaying from the beginning. It applies only
+// to the bootstrap read; once the cursor is persisted, resume is always from it.
+// Use it when historical backlog is irrelevant and only new events matter.
+func WithBootstrapFromTail() S2Option {
+	return func(s *s2Source) { s.bootstrapFromTail = true }
 }
 
 // NewS2 builds an S2 inbox Source for one event feed. The caller resolves the
@@ -113,9 +127,8 @@ func NewS2(feedStream stream.Stream, config stream.S2StreamProviderConfig,
 		src.leader = leader
 		src.leaderAdapter = nil
 	}
-	src.newSession = func(ctx context.Context, startPosition string) (stream.StreamReadSession, error) {
-		return stream.NewS2StreamReadSession(ctx, src.config, src.basinResolver, src.stream,
-			stream.StreamReadOptions{StartPosition: startPosition})
+	src.newSession = func(ctx context.Context, readOpts stream.StreamReadOptions) (stream.StreamReadSession, error) {
+		return stream.NewS2StreamReadSession(ctx, src.config, src.basinResolver, src.stream, readOpts)
 	}
 	return src, nil
 }
@@ -188,9 +201,14 @@ func (s *s2Source) reopen(ctx context.Context) error {
 	if err != nil && !errors.Is(err, inbox.ErrNoCursor) {
 		return err
 	}
-	// ErrNoCursor leaves position == "" — the bootstrap signal that opens the
-	// read session at the start of the stream (StreamReadOptions treats an empty
-	// StartPosition as "from the beginning").
+	// ErrNoCursor leaves position == "" — the bootstrap signal. By default an
+	// empty StartPosition reads from the beginning; WithBootstrapFromTail instead
+	// starts at the live tail. Either way, once a cursor exists position is
+	// non-empty and resume is from it.
+	readOpts := stream.StreamReadOptions{StartPosition: position}
+	if position == "" && s.bootstrapFromTail {
+		readOpts = stream.StreamReadOptions{FromTail: true}
+	}
 
 	if position == s.lastOpenPosition {
 		s.redeliverAttempts++
@@ -204,7 +222,7 @@ func (s *s2Source) reopen(ctx context.Context) error {
 			s.consumerName, s.feed, position, s.redeliverAttempts)
 	}
 
-	session, err := s.newSession(ctx, position)
+	session, err := s.newSession(ctx, readOpts)
 	if err != nil {
 		return err
 	}

--- a/events/inbox/sources/s2_test.go
+++ b/events/inbox/sources/s2_test.go
@@ -117,6 +117,33 @@ func TestS2Source_BootstrapFromTailOnlyOnFirstOpen(t *testing.T) {
 	assert.Equal(t, "6", script.openOpts[1].StartPosition)
 }
 
+func TestS2Source_BootstrapFromTailRedeliversUnackedRecord(t *testing.T) {
+	// The first live tail record fails before any ack: the reopen must redeliver it
+	// (resume at its position), not re-tail past it — at-least-once for record one.
+	cursors := newMemCursors()
+	script := &sessionScript{sessions: []*fakeSession{
+		{records: []*stream.StreamRecord{rec("a", "5", "6")}},
+		{records: []*stream.StreamRecord{rec("a", "5", "6")}}, // redelivered on reopen
+	}}
+	src := newSource(cursors, script)
+	src.bootstrapFromTail = true
+	ctx := context.Background()
+
+	d, err := src.Receive(ctx)
+	require.NoError(t, err)
+	require.NoError(t, d.Nack()) // handler failed before ack
+
+	d2, err := src.Receive(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("a"), d2.Payload, "unacked bootstrap record is redelivered")
+
+	require.Len(t, script.openOpts, 2)
+	assert.True(t, script.openOpts[0].FromTail, "first open is the tail")
+	assert.False(t, script.openOpts[1].FromTail, "reopen resumes at the read position, not a fresh tail")
+	assert.Equal(t, "5", script.openOpts[1].StartPosition)
+	assert.Equal(t, "", cursors.m["consumer-a|feed.v1.X"], "no ack means no persisted cursor")
+}
+
 func TestS2Source_AckAdvancesCursorAndReopensPastIt(t *testing.T) {
 	cursors := newMemCursors()
 	script := &sessionScript{sessions: []*fakeSession{

--- a/events/inbox/sources/s2_test.go
+++ b/events/inbox/sources/s2_test.go
@@ -60,16 +60,18 @@ func (c *memCursors) Advance(_ context.Context, consumer, feed, position string)
 	return nil
 }
 
-// sessionScript hands out pre-built sessions in order, recording the position
-// each (re)open was requested at.
+// sessionScript hands out pre-built sessions in order, recording the options
+// each (re)open was requested with.
 type sessionScript struct {
 	sessions      []*fakeSession
 	i             int
 	openPositions []string
+	openOpts      []stream.StreamReadOptions
 }
 
-func (s *sessionScript) open(_ context.Context, startPosition string) (stream.StreamReadSession, error) {
-	s.openPositions = append(s.openPositions, startPosition)
+func (s *sessionScript) open(_ context.Context, opts stream.StreamReadOptions) (stream.StreamReadSession, error) {
+	s.openPositions = append(s.openPositions, opts.StartPosition)
+	s.openOpts = append(s.openOpts, opts)
 	sess := s.sessions[s.i]
 	s.i++
 	return sess, nil
@@ -86,6 +88,33 @@ func newSource(cursors *memCursors, script *sessionScript) *s2Source {
 
 func rec(body, position, next string) *stream.StreamRecord {
 	return &stream.StreamRecord{Body: []byte(body), Position: position, Next: next}
+}
+
+func TestS2Source_BootstrapFromTailOnlyOnFirstOpen(t *testing.T) {
+	cursors := newMemCursors()
+	script := &sessionScript{sessions: []*fakeSession{
+		{records: []*stream.StreamRecord{rec("a", "5", "6")}}, // bootstrap read at tail
+		{},                                                    // reopen after ack: from cursor
+	}}
+	src := newSource(cursors, script)
+	src.bootstrapFromTail = true
+	ctx := context.Background()
+
+	d, err := src.Receive(ctx)
+	require.NoError(t, err)
+	require.NoError(t, d.Ack())
+
+	// reopen after the EOF on session 0.
+	_, err = src.Receive(ctx) // session 0 EOF
+	require.ErrorIs(t, err, io.EOF)
+	_, err = src.Receive(ctx) // reopen -> session 1
+	require.ErrorIs(t, err, io.EOF)
+
+	require.Len(t, script.openOpts, 2)
+	assert.True(t, script.openOpts[0].FromTail, "first open (no cursor) starts at tail")
+	assert.Equal(t, "", script.openOpts[0].StartPosition)
+	assert.False(t, script.openOpts[1].FromTail, "after a cursor exists, resume from position")
+	assert.Equal(t, "6", script.openOpts[1].StartPosition)
 }
 
 func TestS2Source_AckAdvancesCursorAndReopensPastIt(t *testing.T) {


### PR DESCRIPTION
## Summary

Small follow-up to #124/#125. Adds `sources.WithBootstrapFromTail()` to the inbox S2 source.

By default a brand-new consumer (no persisted cursor) replays from the **start** of the feed (the spec's bootstrap behavior). `WithBootstrapFromTail` instead starts the **bootstrap** read at the live **tail** — for consumers that only care about new events and want to skip historical backlog. Only the bootstrap is affected; once a cursor is persisted, resume is always from it.

## Why

The first malysis consumer on the inbox — the threat-monitor migration off the legacy `monitor-package-versions` raw stream — wants to cut over at the tail (the producer dual-publishes, so the backlog on the standard `PackageVersionObservationEvent` feed is already-seen data and replaying it isn't desired). There was no way to express "start at tail on bootstrap" from the consumer side without reaching past the inbox abstraction into S2.

## Implementation

- `WithBootstrapFromTail()` option sets a `bootstrapFromTail` flag.
- `reopen` picks `StreamReadOptions{FromTail: true}` only when there's no cursor yet (`position == ""`); otherwise resumes from the persisted position as before.
- The internal session factory now takes full `StreamReadOptions` (was just a start position) so `reopen` can choose tail-vs-position. Public `NewS2` is unchanged apart from the new variadic option.

## Testing

- New test asserts the first open (no cursor) uses `FromTail`, and the reopen after the first ack resumes from the persisted position (not tail).
- `go build`, `go vet`, `go test ./events/inbox/...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018EeQr2DxAQAPfzNJnuja7W)_