### PR TITLE
feat(events/outbox): add a read-only aggregate stats API (StatsReader)

### DIFF
--- a/events/outbox/stats.go
+++ b/events/outbox/stats.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/safedep/dry/db"
-	"gorm.io/gorm"
 )
 
 // StatsReader exposes read-only aggregate views over the outbox tables for a
@@ -60,33 +59,36 @@ func (r *StatsReader) StateTotals(ctx context.Context, since time.Time) (StateTo
 	}
 	gdb = gdb.WithContext(ctx)
 
-	scope := func(tx *gorm.DB) *gorm.DB {
-		if since.IsZero() {
-			return tx
-		}
-		return tx.Where("created_at >= ?", since)
+	// One aggregate so every count comes from a single consistent snapshot.
+	// Separate Count statements could interleave with Emit/drain/cleanup and break
+	// the delivered+pending=emitted partition (e.g. observe Delivered > Emitted).
+	// Stuck is SUM over a correlated EXISTS: undelivered records carrying a delivery
+	// flagged past maxAttempts. COALESCE keeps the empty-window result 0, not NULL.
+	const stuckSum = "COALESCE(SUM(CASE WHEN delivered_at IS NULL AND " +
+		"EXISTS (SELECT 1 FROM event_outbox_delivery d WHERE d.outbox_id = event_outbox.id AND d.stuck_since IS NOT NULL) " +
+		"THEN 1 ELSE 0 END), 0) AS stuck"
+
+	q := gdb.Model(&Record{}).
+		Select("COUNT(*) AS emitted, COUNT(delivered_at) AS delivered, " + stuckSum)
+	if !since.IsZero() {
+		q = q.Where("created_at >= ?", since)
 	}
 
-	var totals StateTotals
-	if err := scope(gdb.Model(&Record{})).Count(&totals.Emitted).Error; err != nil {
-		return StateTotals{}, fmt.Errorf("outbox: count emitted: %w", err)
+	var row struct {
+		Emitted   int64
+		Delivered int64
+		Stuck     int64
 	}
-	if err := scope(gdb.Model(&Record{})).Where("delivered_at IS NOT NULL").Count(&totals.Delivered).Error; err != nil {
-		return StateTotals{}, fmt.Errorf("outbox: count delivered: %w", err)
-	}
-	totals.Pending = totals.Emitted - totals.Delivered
-
-	// Stuck records: undelivered and carrying at least one delivery flagged stuck.
-	// EXISTS keeps it a single scan of records with a correlated probe.
-	stuckProbe := "EXISTS (SELECT 1 FROM event_outbox_delivery d WHERE d.outbox_id = event_outbox.id AND d.stuck_since IS NOT NULL)"
-	if err := scope(gdb.Model(&Record{})).
-		Where("delivered_at IS NULL").
-		Where(stuckProbe).
-		Count(&totals.Stuck).Error; err != nil {
-		return StateTotals{}, fmt.Errorf("outbox: count stuck: %w", err)
+	if err := q.Scan(&row).Error; err != nil {
+		return StateTotals{}, fmt.Errorf("outbox: state totals: %w", err)
 	}
 
-	return totals, nil
+	return StateTotals{
+		Emitted:   row.Emitted,
+		Delivered: row.Delivered,
+		Pending:   row.Emitted - row.Delivered,
+		Stuck:     row.Stuck,
+	}, nil
 }
 
 // PerFQN returns the per-event-type breakdown, busiest feed first. A zero since

--- a/events/outbox/stats.go
+++ b/events/outbox/stats.go
@@ -1,0 +1,176 @@
+package outbox
+
+import (
+	"context"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/safedep/dry/db"
+	"gorm.io/gorm"
+)
+
+// StatsReader exposes read-only aggregate views over the outbox tables for a
+// monitoring UI. It is independent of Outbox (the writer/drain): a consumer that
+// only displays pipeline health constructs a reader over its database without
+// owning any destinations.
+type StatsReader struct {
+	store db.SqlDataAdapter
+}
+
+// NewStatsReader builds a reader over the consumer's outbox database.
+func NewStatsReader(store db.SqlDataAdapter) (*StatsReader, error) {
+	if store == nil {
+		return nil, errors.New("outbox: NewStatsReader requires a store")
+	}
+
+	return &StatsReader{store: store}, nil
+}
+
+// StateTotals is the headline delivery state across all events. Delivered and
+// Pending partition Emitted (every record is one or the other). Stuck is a
+// subset of Pending: an undelivered record with at least one delivery past
+// maxAttempts — surfaced separately for alerting, not a fourth bucket.
+type StateTotals struct {
+	Emitted   int64
+	Delivered int64
+	Pending   int64
+	Stuck     int64
+}
+
+// FQNStat is the per-event-type breakdown row. Pending is Emitted-Delivered (all
+// records of this FQN not yet fully delivered). LastEmitted is the most recent
+// emission, for spotting feeds that have gone quiet.
+type FQNStat struct {
+	FQN         string
+	Emitted     int64
+	Delivered   int64
+	Pending     int64
+	LastEmitted time.Time
+}
+
+// StateTotals returns the headline counts. A zero since includes all history;
+// otherwise only records emitted at or after since are counted (the UI maps its
+// time-range dropdown onto since).
+func (r *StatsReader) StateTotals(ctx context.Context, since time.Time) (StateTotals, error) {
+	gdb, err := r.store.GetDB()
+	if err != nil {
+		return StateTotals{}, fmt.Errorf("outbox: get db: %w", err)
+	}
+	gdb = gdb.WithContext(ctx)
+
+	scope := func(tx *gorm.DB) *gorm.DB {
+		if since.IsZero() {
+			return tx
+		}
+		return tx.Where("created_at >= ?", since)
+	}
+
+	var totals StateTotals
+	if err := scope(gdb.Model(&Record{})).Count(&totals.Emitted).Error; err != nil {
+		return StateTotals{}, fmt.Errorf("outbox: count emitted: %w", err)
+	}
+	if err := scope(gdb.Model(&Record{})).Where("delivered_at IS NOT NULL").Count(&totals.Delivered).Error; err != nil {
+		return StateTotals{}, fmt.Errorf("outbox: count delivered: %w", err)
+	}
+	totals.Pending = totals.Emitted - totals.Delivered
+
+	// Stuck records: undelivered and carrying at least one delivery flagged stuck.
+	// EXISTS keeps it a single scan of records with a correlated probe.
+	stuckProbe := "EXISTS (SELECT 1 FROM event_outbox_delivery d WHERE d.outbox_id = event_outbox.id AND d.stuck_since IS NOT NULL)"
+	if err := scope(gdb.Model(&Record{})).
+		Where("delivered_at IS NULL").
+		Where(stuckProbe).
+		Count(&totals.Stuck).Error; err != nil {
+		return StateTotals{}, fmt.Errorf("outbox: count stuck: %w", err)
+	}
+
+	return totals, nil
+}
+
+// PerFQN returns the per-event-type breakdown, busiest feed first. A zero since
+// includes all history; otherwise only records emitted at or after since count.
+func (r *StatsReader) PerFQN(ctx context.Context, since time.Time) ([]FQNStat, error) {
+	gdb, err := r.store.GetDB()
+	if err != nil {
+		return nil, fmt.Errorf("outbox: get db: %w", err)
+	}
+	gdb = gdb.WithContext(ctx)
+
+	q := gdb.Model(&Record{}).
+		Select("fqn AS fqn, COUNT(*) AS emitted, COUNT(delivered_at) AS delivered, MAX(created_at) AS last_emitted").
+		Group("fqn").
+		Order("emitted DESC")
+	if !since.IsZero() {
+		q = q.Where("created_at >= ?", since)
+	}
+
+	var rows []fqnRow
+	if err := q.Scan(&rows).Error; err != nil {
+		return nil, fmt.Errorf("outbox: per-fqn breakdown: %w", err)
+	}
+
+	out := make([]FQNStat, len(rows))
+	for i, r := range rows {
+		out[i] = FQNStat{
+			FQN:         r.FQN,
+			Emitted:     r.Emitted,
+			Delivered:   r.Delivered,
+			Pending:     r.Emitted - r.Delivered,
+			LastEmitted: r.LastEmitted.t,
+		}
+	}
+
+	return out, nil
+}
+
+// fqnRow is the raw scan target for PerFQN. LastEmitted is a scannedTime because
+// MAX(created_at) loses datetime affinity under SQLite (returned as text) while
+// Postgres returns a time.Time — scannedTime accepts both.
+type fqnRow struct {
+	FQN         string
+	Emitted     int64
+	Delivered   int64
+	LastEmitted scannedTime
+}
+
+// scannedTime reads a timestamp that a driver may hand back as time.Time
+// (Postgres) or as a text/byte string (SQLite aggregate columns). It implements
+// driver.Valuer too so GORM treats it as a scalar column, not a relation.
+type scannedTime struct{ t time.Time }
+
+func (s scannedTime) Value() (driver.Value, error) { return s.t, nil }
+
+func (s *scannedTime) Scan(v any) error {
+	switch x := v.(type) {
+	case nil:
+		return nil
+	case time.Time:
+		s.t = x
+		return nil
+	case []byte:
+		return s.parse(string(x))
+	case string:
+		return s.parse(x)
+	default:
+		return fmt.Errorf("outbox: cannot scan %T into time", v)
+	}
+}
+
+func (s *scannedTime) parse(v string) error {
+	for _, layout := range []string{
+		time.RFC3339Nano,
+		"2006-01-02 15:04:05.999999999-07:00",
+		"2006-01-02 15:04:05-07:00",
+		"2006-01-02 15:04:05.999999999",
+		"2006-01-02 15:04:05",
+	} {
+		if t, err := time.Parse(layout, v); err == nil {
+			s.t = t
+			return nil
+		}
+	}
+
+	return fmt.Errorf("outbox: unrecognized time format %q", v)
+}

--- a/events/outbox/stats_test.go
+++ b/events/outbox/stats_test.go
@@ -1,0 +1,140 @@
+package outbox
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedRecord inserts one outbox record with a controlled FQN, emission time, and
+// delivery state directly (dry owns the model), so a stats scenario can be built
+// without driving the drain into each state.
+func seedRecord(t *testing.T, a testAdapter, id, fqn string, createdAt time.Time, delivered, stuck bool) {
+	t.Helper()
+	gdb, err := a.GetDB()
+	require.NoError(t, err)
+
+	rec := &Record{EventID: id, FQN: fqn, Subject: "pkg:npm/x", CreatedAt: createdAt}
+	if delivered {
+		d := createdAt.Add(time.Minute)
+		rec.DeliveredAt = &d
+	}
+	require.NoError(t, gdb.Create(rec).Error)
+
+	del := &Delivery{OutboxID: rec.ID, Destination: "s2", Subject: rec.Subject}
+	if delivered {
+		p := createdAt.Add(time.Minute)
+		del.PublishedAt = &p
+	}
+	if stuck {
+		s := createdAt.Add(2 * time.Minute)
+		del.StuckSince = &s
+	}
+	require.NoError(t, gdb.Create(del).Error)
+}
+
+// statsFixture seeds a known mix of records across two feeds and delivery states.
+//
+//	A: r1 delivered | r2 pending | r3 stuck
+//	B: r4 delivered | r5 pending
+func statsFixture(t *testing.T, now time.Time) *StatsReader {
+	t.Helper()
+	a := newStore(t)
+	seedRecord(t, a, "r1", "feed.A", now.Add(-10*time.Minute), true, false)
+	seedRecord(t, a, "r2", "feed.A", now.Add(-5*time.Minute), false, false)
+	seedRecord(t, a, "r3", "feed.A", now.Add(-1*time.Minute), false, true)
+	seedRecord(t, a, "r4", "feed.B", now.Add(-3*time.Minute), true, false)
+	seedRecord(t, a, "r5", "feed.B", now.Add(-20*time.Minute), false, false)
+
+	r, err := NewStatsReader(a)
+	require.NoError(t, err)
+	return r
+}
+
+func TestNewStatsReader_NilStore(t *testing.T) {
+	_, err := NewStatsReader(nil)
+	require.Error(t, err)
+}
+
+func TestStatsReader_StateTotals(t *testing.T) {
+	now := time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC)
+	r := statsFixture(t, now)
+
+	tests := []struct {
+		name  string
+		since time.Time
+		want  StateTotals
+	}{
+		{
+			name:  "all history partitions into delivered + pending, stuck is a subset",
+			since: time.Time{},
+			want:  StateTotals{Emitted: 5, Delivered: 2, Pending: 3, Stuck: 1},
+		},
+		{
+			name:  "since window drops the two oldest records",
+			since: now.Add(-6 * time.Minute), // keeps r2, r3, r4; drops r1, r5
+			want:  StateTotals{Emitted: 3, Delivered: 1, Pending: 2, Stuck: 1},
+		},
+		{
+			name:  "future since yields an empty window",
+			since: now.Add(time.Hour),
+			want:  StateTotals{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := r.StateTotals(context.Background(), tt.since)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+			// Delivered + Pending always reconstruct Emitted.
+			assert.Equal(t, got.Emitted, got.Delivered+got.Pending)
+		})
+	}
+}
+
+func TestStatsReader_PerFQN(t *testing.T) {
+	now := time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC)
+	r := statsFixture(t, now)
+
+	t.Run("all history, busiest feed first", func(t *testing.T) {
+		got, err := r.PerFQN(context.Background(), time.Time{})
+		require.NoError(t, err)
+		require.Len(t, got, 2)
+
+		assert.Equal(t, "feed.A", got[0].FQN)
+		assert.Equal(t, int64(3), got[0].Emitted)
+		assert.Equal(t, int64(1), got[0].Delivered)
+		assert.Equal(t, int64(2), got[0].Pending)
+		assert.WithinDuration(t, now.Add(-1*time.Minute), got[0].LastEmitted, time.Second)
+
+		assert.Equal(t, "feed.B", got[1].FQN)
+		assert.Equal(t, int64(2), got[1].Emitted)
+		assert.Equal(t, int64(1), got[1].Delivered)
+		assert.Equal(t, int64(1), got[1].Pending)
+		assert.WithinDuration(t, now.Add(-3*time.Minute), got[1].LastEmitted, time.Second)
+	})
+
+	t.Run("since window narrows per-feed counts", func(t *testing.T) {
+		got, err := r.PerFQN(context.Background(), now.Add(-6*time.Minute))
+		require.NoError(t, err)
+		require.Len(t, got, 2)
+
+		byFQN := map[string]FQNStat{got[0].FQN: got[0], got[1].FQN: got[1]}
+		assert.Equal(t, int64(2), byFQN["feed.A"].Emitted) // r2, r3
+		assert.Equal(t, int64(0), byFQN["feed.A"].Delivered)
+		assert.Equal(t, int64(1), byFQN["feed.B"].Emitted) // r4
+		assert.Equal(t, int64(1), byFQN["feed.B"].Delivered)
+	})
+
+	t.Run("empty store yields no rows", func(t *testing.T) {
+		empty, err := NewStatsReader(newStore(t))
+		require.NoError(t, err)
+		got, err := empty.PerFQN(context.Background(), time.Time{})
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+}


### PR DESCRIPTION
## What

Adds `StatsReader`, a read-only aggregate view over the `event_outbox` / `event_outbox_delivery` tables, for a monitoring UI (the malbase **Platform Events → Overview** page). It is independent of `Outbox` (the writer/drain): a consumer that only displays pipeline health constructs a reader over its database without owning any destinations.

### API

```go
r, _ := outbox.NewStatsReader(store)              // store db.SqlDataAdapter
totals, _ := r.StateTotals(ctx, since)            // headline counts
perFQN, _ := r.PerFQN(ctx, since)                 // per-event-type breakdown
```

- **`StateTotals`** — `Emitted`, `Delivered`, `Pending`, `Stuck`. `Delivered + Pending` partition `Emitted`; `Stuck` is the *subset* of `Pending` that has a delivery flagged past `maxAttempts` (surfaced for alerting, not a fourth bucket).
- **`PerFQN`** — per event type: `Emitted` / `Delivered` / `Pending` + `LastEmitted` (most recent emission), busiest feed first.
- Both take a `since time.Time`; a zero value means **all history**, otherwise only records emitted at/after `since` count. The caller (UI) owns time-range bucketing (`1h / 24h / 7d / 30d / all`), so dry stays generic.
- Strictly read-only — no drain state is touched.

## Why

`dry/events/outbox` owned the model + drain queries but exposed no read API for a UI. This is the prerequisite for the malbase Events Overview page.

## Notes

- `PerFQN` scans `MAX(created_at)` through a small tolerant `scannedTime` scanner: SQLite hands aggregate timestamps back as text while Postgres returns `time.Time` — the scanner accepts both, so the same code is correct under the production Postgres and the sqlite-backed unit tests.
- **Out of scope** (per design): per-record list / Get-by-id / payload decode. This milestone is aggregate-only; a record browser can be added later if wanted.

## Tests

`stats_test.go` — sqlite-backed, table-driven: `StateTotals` partition + stuck subset + `since` windows (including empty/future windows); `PerFQN` breakdown, ordering, last-emitted, `since` narrowing, and empty store. `go test ./events/outbox/...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018EeQr2DxAQAPfzNJnuja7W)_