### PR TITLE
fix(usefulerror): unwrap nested Any layers when extracting gRPC ErrorInfo

### DIFF
--- a/usefulerror/convert_grpc.go
+++ b/usefulerror/convert_grpc.go
@@ -191,24 +191,43 @@ func init() {
 	})
 }
 
+// maxErrorInfoAnyNesting bounds how many google.protobuf.Any layers we unwrap
+// when looking for an ErrorInfo detail. Servers that re-wrap a status while
+// propagating an error (e.g. control-tower serror.Add) can nest the detail one
+// Any layer deeper per wrap; the bound keeps hostile payloads from recursing.
+const maxErrorInfoAnyNesting = 8
+
 // getErrorInfoFromGrpcStatusDetails extracts the first ErrorInfo detail from a gRPC status, if present.
 func getErrorInfoFromGrpcStatusDetails(st *status.Status) (*errdetails.ErrorInfo, bool) {
 	for _, d := range st.Details() {
-		switch det := d.(type) {
-		// When the underlying lib already deserialized
+		msg, ok := d.(proto.Message)
+		if !ok {
+			continue
+		}
+
+		if ei, ok := errorInfoFromDetail(msg); ok {
+			return ei, true
+		}
+	}
+
+	return nil, false
+}
+
+func errorInfoFromDetail(msg proto.Message) (*errdetails.ErrorInfo, bool) {
+	for range maxErrorInfoAnyNesting {
+		switch det := msg.(type) {
 		case *errdetails.ErrorInfo:
 			return det, true
 
-		// When the detail is of a generic type, we will try to unmarshal it to ErrorInfo
 		case *anypb.Any:
-			if det.GetTypeUrl() != "type.googleapis.com/google.rpc.ErrorInfo" {
-				continue
+			unpacked, err := det.UnmarshalNew()
+			if err != nil {
+				return nil, false
 			}
+			msg = unpacked
 
-			var ei errdetails.ErrorInfo
-			if err := proto.Unmarshal(det.GetValue(), &ei); err == nil {
-				return &ei, true
-			}
+		default:
+			return nil, false
 		}
 	}
 

--- a/usefulerror/convert_grpc.go
+++ b/usefulerror/convert_grpc.go
@@ -215,27 +215,24 @@ func getErrorInfoFromGrpcStatusDetails(st *status.Status) (*errdetails.ErrorInfo
 
 func errorInfoFromDetail(msg proto.Message) (*errdetails.ErrorInfo, bool) {
 	for range maxErrorInfoAnyNesting {
-		switch det := msg.(type) {
-		case *errdetails.ErrorInfo:
-			return det, true
+		det, ok := msg.(*anypb.Any)
+		if !ok {
+			break
+		}
 
-		case *anypb.Any:
-			// Only unmarshal the two types we can act on; status details are
-			// untrusted input, so skip decoding arbitrary message types.
-			if !det.MessageIs((*errdetails.ErrorInfo)(nil)) && !det.MessageIs((*anypb.Any)(nil)) {
-				return nil, false
-			}
-
-			unpacked, err := det.UnmarshalNew()
-			if err != nil {
-				return nil, false
-			}
-			msg = unpacked
-
-		default:
+		// Only unmarshal the two types we can act on; status details are
+		// untrusted input, so skip decoding arbitrary message types.
+		if !det.MessageIs((*errdetails.ErrorInfo)(nil)) && !det.MessageIs((*anypb.Any)(nil)) {
 			return nil, false
 		}
+
+		unpacked, err := det.UnmarshalNew()
+		if err != nil {
+			return nil, false
+		}
+		msg = unpacked
 	}
 
-	return nil, false
+	ei, ok := msg.(*errdetails.ErrorInfo)
+	return ei, ok
 }

--- a/usefulerror/convert_grpc.go
+++ b/usefulerror/convert_grpc.go
@@ -220,6 +220,12 @@ func errorInfoFromDetail(msg proto.Message) (*errdetails.ErrorInfo, bool) {
 			return det, true
 
 		case *anypb.Any:
+			// Only unmarshal the two types we can act on; status details are
+			// untrusted input, so skip decoding arbitrary message types.
+			if !det.MessageIs((*errdetails.ErrorInfo)(nil)) && !det.MessageIs((*anypb.Any)(nil)) {
+				return nil, false
+			}
+
 			unpacked, err := det.UnmarshalNew()
 			if err != nil {
 				return nil, false

--- a/usefulerror/convert_grpc_test.go
+++ b/usefulerror/convert_grpc_test.go
@@ -257,9 +257,27 @@ func TestConvertGRPCToUsefulError_PermissionDenied_WithNestedAnyDetail(t *testin
 		result, ok := AsUsefulError(status.FromProto(stProto).Err())
 		assert.True(t, ok)
 		assert.NotNil(t, result)
-		assert.Equalf(t, ErrMissingEntitlements, result.Code(), "nesting depth %d", depth)
+		assert.Equalf(t, ErrMissingEntitlements, result.Code(), "extra Any wrap layers: %d (total nesting %d)", depth, depth+1)
 		assert.Equal(t, "Access to this feature requires a SafeDep subscription. See https://safedep.io/pricing", result.Help())
 	}
+}
+
+func TestErrorInfoFromDetailNestingBound(t *testing.T) {
+	var msg proto.Message = &errdetails.ErrorInfo{Reason: ErrAppEntitlementNotAvailable}
+	for range maxErrorInfoAnyNesting {
+		packed, err := anypb.New(msg)
+		assert.NoError(t, err)
+		msg = packed
+	}
+
+	ei, ok := errorInfoFromDetail(msg)
+	assert.True(t, ok, "ErrorInfo at exactly maxErrorInfoAnyNesting layers must be found")
+	assert.Equal(t, ErrAppEntitlementNotAvailable, ei.GetReason())
+
+	over, err := anypb.New(msg)
+	assert.NoError(t, err)
+	_, ok = errorInfoFromDetail(over)
+	assert.False(t, ok, "ErrorInfo beyond maxErrorInfoAnyNesting layers must be rejected")
 }
 
 func TestConvertGRPCToUsefulError_UnrelatedNestedDetailIsNotUnwrapped(t *testing.T) {

--- a/usefulerror/convert_grpc_test.go
+++ b/usefulerror/convert_grpc_test.go
@@ -262,6 +262,25 @@ func TestConvertGRPCToUsefulError_PermissionDenied_WithNestedAnyDetail(t *testin
 	}
 }
 
+func TestConvertGRPCToUsefulError_UnrelatedNestedDetailIsNotUnwrapped(t *testing.T) {
+	// A nested Any wrapping something other than ErrorInfo (or another Any)
+	// must not be decoded or classified as an entitlement failure.
+	retry, err := anypb.New(&errdetails.RetryInfo{})
+	assert.NoError(t, err)
+
+	nested, err := anypb.New(retry)
+	assert.NoError(t, err)
+
+	st := status.New(codes.PermissionDenied, "no access")
+	stProto := st.Proto()
+	stProto.Details = append(stProto.Details, nested)
+
+	result, ok := AsUsefulError(status.FromProto(stProto).Err())
+	assert.True(t, ok)
+	assert.NotNil(t, result)
+	assert.Equal(t, ErrAuthorizationFailed, result.Code())
+}
+
 func TestConvertGRPCToUsefulError_ResourceExhausted_WithDetails_LimitReached(t *testing.T) {
 	// Build a gRPC status with ErrorInfo reason=quota_exceeded and metadata reason=limit_reached
 	st := status.New(codes.ResourceExhausted, "rate limit reached")

--- a/usefulerror/convert_grpc_test.go
+++ b/usefulerror/convert_grpc_test.go
@@ -230,6 +230,38 @@ func TestConvertGRPCToUsefulError_PermissionDenied_WithAnypbDetail(t *testing.T)
 	assert.Contains(t, result.AdditionalHelp(), "no access")
 }
 
+func TestConvertGRPCToUsefulError_PermissionDenied_WithNestedAnyDetail(t *testing.T) {
+	// Regression: control-tower's serror.Add used to re-pack already-packed
+	// Any details on every wrap. The entitlement error passed through two
+	// Add calls (service executor + API handler), so the ErrorInfo arrived
+	// nested two Any layers deep. Extraction must unwrap nested Any layers.
+	ei := &errdetails.ErrorInfo{
+		Reason: ErrAppEntitlementNotAvailable,
+		Domain: "safedep.io",
+		Metadata: map[string]string{
+			"feature": "some_feature",
+		},
+	}
+
+	packed, err := anypb.New(ei)
+	assert.NoError(t, err)
+
+	for depth := 1; depth <= 2; depth++ {
+		packed, err = anypb.New(packed)
+		assert.NoError(t, err)
+
+		st := status.New(codes.PermissionDenied, "no access")
+		stProto := st.Proto()
+		stProto.Details = append(stProto.Details, packed)
+
+		result, ok := AsUsefulError(status.FromProto(stProto).Err())
+		assert.True(t, ok)
+		assert.NotNil(t, result)
+		assert.Equal(t, ErrMissingEntitlements, result.Code(), "nesting depth %d", depth)
+		assert.Equal(t, "Access to this feature requires a SafeDep subscription. See https://safedep.io/pricing", result.Help())
+	}
+}
+
 func TestConvertGRPCToUsefulError_ResourceExhausted_WithDetails_LimitReached(t *testing.T) {
 	// Build a gRPC status with ErrorInfo reason=quota_exceeded and metadata reason=limit_reached
 	st := status.New(codes.ResourceExhausted, "rate limit reached")

--- a/usefulerror/convert_grpc_test.go
+++ b/usefulerror/convert_grpc_test.go
@@ -257,7 +257,7 @@ func TestConvertGRPCToUsefulError_PermissionDenied_WithNestedAnyDetail(t *testin
 		result, ok := AsUsefulError(status.FromProto(stProto).Err())
 		assert.True(t, ok)
 		assert.NotNil(t, result)
-		assert.Equal(t, ErrMissingEntitlements, result.Code(), "nesting depth %d", depth)
+		assert.Equalf(t, ErrMissingEntitlements, result.Code(), "nesting depth %d", depth)
 		assert.Equal(t, "Access to this feature requires a SafeDep subscription. See https://safedep.io/pricing", result.Help())
 	}
 }


### PR DESCRIPTION
## Problem

`pmg cloud sync` reported "network unreachable" when the real failure was a missing entitlement. Part of the RCA: control-tower's `serror.Add` re-packs already-packed `Any` status details on every wrap, and the entitlement error passes through two wraps (service executor + API handler), so the `ErrorInfo` detail arrives nested two `google.protobuf.Any` layers deep.

`getErrorInfoFromGrpcStatusDetails` tolerated exactly one stray `Any` layer, so entitlement (and quota) classification silently fell back to generic authorization/quota errors.

## Fix

Unwrap `Any` layers iteratively (bounded at 8 levels to keep hostile payloads from recursing) before matching `ErrorInfo`. Classification now works regardless of how many times the server re-wrapped the status. Benefits both the `PermissionDenied` (entitlements) and `ResourceExhausted` (quota) converters.

## Testing

- New regression test covers `ErrorInfo` nested 2 and 3 `Any` layers deep (the exact wire format produced by current production control-tower) → classified as `missing_entitlements`.
- Existing depth-0/depth-1 tests unchanged and green.

## Related

Part of a three-repo fix for the `pmg cloud sync` misleading-error incident:
- `safedep/control-tower` #1050 — fixes the root cause (`serror.Add` detail re-packing)
- `safedep/pmg` — stop masking backend errors as network errors; bumps dry to pick up this fix

This is defense in depth: it keeps every dry-based client classifying correctly against already-deployed control-tower versions and any other double-wrap path not yet audited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MHdvpFXb2shyMzUDyR8QKA

---
_Generated by [Claude Code](https://claude.ai/code/session_01MHdvpFXb2shyMzUDyR8QKA)_