### PR TITLE
feat(tui/panel): improve readability with border title and breathing room

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/caarlos0/env/v11 v11.3.1
 	github.com/charmbracelet/colorprofile v0.4.1
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/charmbracelet/x/ansi v0.11.5
 	github.com/cloudwego/eino v0.7.13
 	github.com/cloudwego/eino-ext/components/model/claude v0.1.17
 	github.com/cloudwego/eino-ext/components/model/gemini v0.1.5
@@ -121,7 +122,6 @@ require (
 	github.com/bytedance/sonic/loader v0.5.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/charmbracelet/x/ansi v0.11.5 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/chigopher/pathlib v0.19.1 // indirect

--- a/tui/panel/panel.go
+++ b/tui/panel/panel.go
@@ -2,9 +2,10 @@
 //
 // Package panel renders a titled key-value detail card. It is the standard
 // presentation for "show one thing" command output (a credential profile,
-// an endpoint, a configuration). Rich mode draws a bordered card with
-// aligned muted labels; Plain and Agent modes degrade to aligned
-// label/value lines with no decoration.
+// an endpoint, a configuration). Rich mode draws a bordered card with the
+// title embedded in the top border, vertical breathing room, and aligned
+// muted labels; Plain and Agent modes degrade to aligned label/value lines
+// with no decoration.
 package panel
 
 import (
@@ -13,8 +14,14 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/safedep/dry/tui/output"
-	"github.com/safedep/dry/tui/style"
 	"github.com/safedep/dry/tui/theme"
+)
+
+// Layout constants for the Rich card. hpad is the space between the border
+// and content on each side. gutter separates the label column from values.
+const (
+	hpad   = 3
+	gutter = 3
 )
 
 type field struct {
@@ -73,26 +80,63 @@ func (p *Panel) renderBasic(labelW int) string {
 	return strings.TrimRight(b.String(), "\n")
 }
 
+// renderRich draws the card manually rather than via lipgloss borders so
+// the title can live on the top border line. lipgloss v1 has no native
+// border-title support.
 func (p *Panel) renderRich(labelW int) string {
-	mutedC, _ := theme.Default().Palette().ColorByRole(theme.RoleMuted)
-	labelStyle := lipgloss.NewStyle().Foreground(mutedC)
+	pal := theme.Default().Palette()
+	mutedC, _ := pal.ColorByRole(theme.RoleMuted)
+	headingC, _ := pal.ColorByRole(theme.RoleHeading)
 
-	var lines []string
-	if p.title != "" {
-		lines = append(lines, style.Heading(p.title))
-		if len(p.fields) > 0 {
-			lines = append(lines, "")
+	borderStyle := lipgloss.NewStyle()
+	labelStyle := lipgloss.NewStyle()
+	titleStyle := lipgloss.NewStyle().Bold(true)
+	if output.IsColorEnabled() {
+		borderStyle = borderStyle.Foreground(mutedC)
+		labelStyle = labelStyle.Foreground(mutedC)
+		titleStyle = titleStyle.Foreground(headingC)
+	}
+
+	rows := make([]string, 0, len(p.fields))
+	contentW := 0
+	for _, f := range p.fields {
+		row := labelStyle.Render(pad(f.label, labelW)) + strings.Repeat(" ", gutter) + f.value
+		rows = append(rows, row)
+		if w := lipgloss.Width(row); w > contentW {
+			contentW = w
 		}
 	}
-	for _, f := range p.fields {
-		lines = append(lines, labelStyle.Render(pad(f.label, labelW))+"  "+f.value)
-	}
 
-	box := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(mutedC).
-		Padding(0, 2)
-	return box.Render(strings.Join(lines, "\n"))
+	// The top border must fit "─ title " plus trailing dashes even when
+	// the title is wider than every row.
+	titleW := lipgloss.Width(p.title)
+	if p.title != "" && titleW+5 > contentW+2*hpad {
+		contentW = titleW + 5 - 2*hpad
+	}
+	inner := contentW + 2*hpad
+
+	var b strings.Builder
+	b.WriteString(topBorder(p.title, inner, borderStyle, titleStyle))
+	if len(rows) > 0 {
+		blank := borderStyle.Render("│") + strings.Repeat(" ", inner) + borderStyle.Render("│")
+		b.WriteString("\n" + blank)
+		for _, row := range rows {
+			b.WriteString("\n" + borderStyle.Render("│") + strings.Repeat(" ", hpad) +
+				row + strings.Repeat(" ", inner-hpad-lipgloss.Width(row)) + borderStyle.Render("│"))
+		}
+		b.WriteString("\n" + blank)
+	}
+	b.WriteString("\n" + borderStyle.Render("╰"+strings.Repeat("─", inner)+"╯"))
+	return b.String()
+}
+
+func topBorder(title string, inner int, borderStyle, titleStyle lipgloss.Style) string {
+	if title == "" {
+		return borderStyle.Render("╭" + strings.Repeat("─", inner) + "╮")
+	}
+	fill := inner - lipgloss.Width(title) - 3
+	return borderStyle.Render("╭─ ") + titleStyle.Render(title) +
+		borderStyle.Render(" "+strings.Repeat("─", fill)+"╮")
 }
 
 func pad(s string, w int) string {

--- a/tui/panel/panel.go
+++ b/tui/panel/panel.go
@@ -90,11 +90,11 @@ func (p *Panel) renderRich(labelW int) string {
 
 	borderStyle := lipgloss.NewStyle()
 	labelStyle := lipgloss.NewStyle()
-	titleStyle := lipgloss.NewStyle().Bold(true)
+	titleStyle := lipgloss.NewStyle()
 	if output.IsColorEnabled() {
 		borderStyle = borderStyle.Foreground(mutedC)
 		labelStyle = labelStyle.Foreground(mutedC)
-		titleStyle = titleStyle.Foreground(headingC)
+		titleStyle = titleStyle.Bold(true).Foreground(headingC)
 	}
 
 	rows := make([]string, 0, len(p.fields))

--- a/tui/panel/panel_test.go
+++ b/tui/panel/panel_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -57,7 +58,7 @@ func TestPanelFieldIf(t *testing.T) {
 func TestPanelRichEmbedsTitleInTopBorder(t *testing.T) {
 	withMode(t, output.Rich)
 
-	got := New("Endpoint").Field("Hostname", "dev-box").Render()
+	got := ansi.Strip(New("Endpoint").Field("Hostname", "dev-box").Render())
 	lines := strings.Split(got, "\n")
 	assert.Contains(t, lines[0], "╭─ Endpoint ─")
 	assert.Contains(t, got, "dev-box")
@@ -67,7 +68,7 @@ func TestPanelRichEmbedsTitleInTopBorder(t *testing.T) {
 func TestPanelRichHasVerticalPadding(t *testing.T) {
 	withMode(t, output.Rich)
 
-	got := New("T").Field("A", "1").Render()
+	got := ansi.Strip(New("T").Field("A", "1").Render())
 	lines := strings.Split(got, "\n")
 	// top border, blank, row, blank, bottom border.
 	require.Len(t, lines, 5)
@@ -104,7 +105,7 @@ func TestPanelRichTitleWiderThanRows(t *testing.T) {
 func TestPanelRichTitleOnlyIsCompact(t *testing.T) {
 	withMode(t, output.Rich)
 
-	got := New("Only Title").Render()
+	got := ansi.Strip(New("Only Title").Render())
 	assert.Contains(t, got, "Only Title")
 	// Top border with title, bottom border.
 	assert.Len(t, strings.Split(got, "\n"), 2)

--- a/tui/panel/panel_test.go
+++ b/tui/panel/panel_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -53,21 +54,58 @@ func TestPanelFieldIf(t *testing.T) {
 	assert.Contains(t, got, "Kept")
 }
 
-func TestPanelRichDrawsBorderAndTitle(t *testing.T) {
+func TestPanelRichEmbedsTitleInTopBorder(t *testing.T) {
 	withMode(t, output.Rich)
 
 	got := New("Endpoint").Field("Hostname", "dev-box").Render()
-	assert.Contains(t, got, "╭")
-	assert.Contains(t, got, "╰")
-	assert.Contains(t, got, "Endpoint")
+	lines := strings.Split(got, "\n")
+	assert.Contains(t, lines[0], "╭─ Endpoint ─")
 	assert.Contains(t, got, "dev-box")
+	assert.True(t, strings.HasPrefix(lines[len(lines)-1], "╰"))
 }
 
-func TestPanelRichSkipsTitleGapWithoutFields(t *testing.T) {
+func TestPanelRichHasVerticalPadding(t *testing.T) {
+	withMode(t, output.Rich)
+
+	got := New("T").Field("A", "1").Render()
+	lines := strings.Split(got, "\n")
+	// top border, blank, row, blank, bottom border.
+	require.Len(t, lines, 5)
+	assert.Empty(t, strings.TrimSpace(strings.Trim(lines[1], "│")), "second line is a blank padding row")
+	assert.Empty(t, strings.TrimSpace(strings.Trim(lines[3], "│")), "fourth line is a blank padding row")
+	assert.Contains(t, lines[2], "A")
+}
+
+func TestPanelRichAllLinesSameWidth(t *testing.T) {
+	withMode(t, output.Rich)
+
+	got := New("Authentication").
+		Field("Status", "partially authenticated").
+		Field("Profile", "default").
+		Render()
+	lines := strings.Split(got, "\n")
+	w := lipgloss.Width(lines[0])
+	for i, l := range lines {
+		assert.Equal(t, w, lipgloss.Width(l), "line %d width", i)
+	}
+}
+
+func TestPanelRichTitleWiderThanRows(t *testing.T) {
+	withMode(t, output.Rich)
+
+	got := New("A Very Long Panel Title Indeed").Field("A", "1").Render()
+	lines := strings.Split(got, "\n")
+	w := lipgloss.Width(lines[0])
+	for i, l := range lines {
+		assert.Equal(t, w, lipgloss.Width(l), "line %d width", i)
+	}
+}
+
+func TestPanelRichTitleOnlyIsCompact(t *testing.T) {
 	withMode(t, output.Rich)
 
 	got := New("Only Title").Render()
 	assert.Contains(t, got, "Only Title")
-	// One content line inside the border: top border, title, bottom border.
-	assert.Len(t, strings.Split(got, "\n"), 3)
+	// Top border with title, bottom border.
+	assert.Len(t, strings.Split(got, "\n"), 2)
 }


### PR DESCRIPTION
## Summary

Follow-up to #129 based on real-terminal feedback: the panel card was visually congested — the title sat one line above the fields inside the box, rows had no vertical breathing room, and the label-to-value gutter was only two spaces.

Component-level redesign so every consumer gets the same improved look:

**Before**
```
╭─────────────────────────────────────╮
│  Authentication                     │
│                                     │
│  Status       [partially auth...]   │
│  Profile      default               │
╰─────────────────────────────────────╯
```

**After**
```
╭─ Authentication ─────────────────────╮
│                                      │
│   Status      [partially auth...]    │
│   Profile     default                │
│                                      │
╰──────────────────────────────────────╯
```

- Title embeds into the top border (bold heading color on a muted border) — clear header/content separation without a cramped title row.
- One line of vertical padding inside the card.
- Label→value gutter and horizontal padding widen to three columns.
- Drawn manually since lipgloss v1 has no border-title support; all lines are ANSI-width-aligned (tested), including when the title is wider than every row.
- Plain and Agent renderings are unchanged.

## Testing

`go test ./tui/... ./examples/tui` passes, including new tests for border-embedded title, vertical padding, uniform line width, and the wide-title edge case. Snapshot golden unchanged (rich mode is excluded from snapshots by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EHaxVKteDxi2e2yALDoMGp

---
_Generated by [Claude Code](https://claude.ai/code/session_01EHaxVKteDxi2e2yALDoMGp)_