### PR TITLE
obs: register histograms with the Prometheus default registry

### DIFF
--- a/obs/metrics_prom.go
+++ b/obs/metrics_prom.go
@@ -165,7 +165,14 @@ func (p *prometheusMetricsProvider) NewHistogram(name, desc string,
 		editor(&histogramOpts)
 	}
 
+	h := prometheus.NewHistogram(histogramOpts)
+
+	// Register with the default registry like the Counter/Gauge/Vec
+	// constructors above; without this the histogram is created but never
+	// collected, so its _bucket/_sum/_count series are never scraped.
+	prometheus.MustRegister(h)
+
 	return &promHistogramReceiver{
-		histogram: prometheus.NewHistogram(histogramOpts),
+		histogram: h,
 	}
 }

--- a/obs/metrics_prom_register_test.go
+++ b/obs/metrics_prom_register_test.go
@@ -1,0 +1,37 @@
+package obs
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// gathered reports whether a metric family with the given fully-qualified
+// name is present in the default registry.
+func gathered(t *testing.T, name string) bool {
+	t.Helper()
+	mfs, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+	for _, mf := range mfs {
+		if mf.GetName() == name {
+			return true
+		}
+	}
+	return false
+}
+
+// TestPrometheusHistogramIsRegistered guards against a regression where
+// NewHistogram constructed a histogram but never registered it, leaving its
+// _bucket/_sum/_count series unscraped. Counter/Gauge/Vec are already covered
+// implicitly by their MustRegister calls; this pins the same for histograms.
+func TestPrometheusHistogramIsRegistered(t *testing.T) {
+	p := NewPrometheusMetricsProvider("reg", "hist")
+
+	h := p.NewHistogram("registered_1", "test")
+	h.Observe(1)
+
+	assert.True(t, gathered(t, "reg_hist_registered_1"),
+		"histogram must be registered with the default registry so it is scraped")
+}


### PR DESCRIPTION
## Summary

`obs.NewHistogram` constructed a `prometheus.Histogram` but never called `prometheus.MustRegister` — unlike `NewCounter`, `NewGauge`, `NewCounterVec`, and `NewGaugeVec`, which all register with the default registry. As a result, **every histogram created through the `obs` API was invisible to the default gatherer**: its `_bucket` / `_sum` / `_count` series were never exposed on `/metrics` and never scraped. Histogram-based dashboard panels (latency percentiles via `histogram_quantile`, etc.) therefore stayed permanently empty regardless of load.

This was surfaced while building a Grafana dashboard for malysis: the counter/gauge panels populated, but every `obs.NewHistogram`-backed latency panel (`server_workflow_exec_latency_sec`, `agentic_analysis_latency_sec`, the triage histograms, …) returned no series.

## Change

- `obs/metrics_prom.go`: register the histogram with `prometheus.MustRegister` in `NewHistogram`, matching the other constructors.
- `obs/metrics_prom_register_test.go`: regression test (testify) asserting the histogram's metric family is present in the default registry after creation. Verified it fails on the pre-fix code and passes with the fix.

## Verification

```
go test ./obs/   # ok
gofmt -l ...      # clean
go vet ./obs/     # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014eYj2UK599DytFTt1c8Q7Z

---
_Generated by [Claude Code](https://claude.ai/code/session_014eYj2UK599DytFTt1c8Q7Z)_