### PR TITLE
feat(keychain): insecure file-only mode with configurable file permissions

### DIFF
--- a/cloud/keychain_options.go
+++ b/cloud/keychain_options.go
@@ -1,6 +1,7 @@
 package cloud
 
 import (
+	"os"
 	"strings"
 
 	"github.com/safedep/dry/keychain"
@@ -18,11 +19,13 @@ const (
 type KeychainOption func(*keychainConfig)
 
 type keychainConfig struct {
-	appName                  string
-	profile                  string
-	keychain                 keychain.Keychain
-	insecureFileFallback     bool
-	insecureFileFallbackPath string
+	appName              string
+	profile              string
+	keychain             keychain.Keychain
+	insecureFileFallback bool
+	insecureFileOnly     bool
+	insecureFilePath     string
+	insecureFileMode     os.FileMode
 }
 
 // WithAppName overrides the default application name for the keychain.
@@ -65,7 +68,19 @@ func WithInsecureFileFallback() KeychainOption {
 func WithInsecureFileFallbackPath(path string) KeychainOption {
 	return func(c *keychainConfig) {
 		c.insecureFileFallback = true
-		c.insecureFileFallbackPath = path
+		c.insecureFilePath = path
+	}
+}
+
+// WithInsecureFileStore forces plaintext file storage at path with the
+// given mode, bypassing the OS keychain even when it is available. A zero
+// mode defaults to 0600. The caller must ensure path's directory exists
+// with appropriate permissions.
+func WithInsecureFileStore(path string, mode os.FileMode) KeychainOption {
+	return func(c *keychainConfig) {
+		c.insecureFileOnly = true
+		c.insecureFilePath = path
+		c.insecureFileMode = mode
 	}
 }
 

--- a/cloud/keychain_options_test.go
+++ b/cloud/keychain_options_test.go
@@ -1,6 +1,7 @@
 package cloud
 
 import (
+	"os"
 	"testing"
 
 	"github.com/safedep/dry/keychain"
@@ -15,7 +16,7 @@ func TestBuildKeychainConfig(t *testing.T) {
 		assert.Equal(t, DefaultProfile, cfg.profile)
 		assert.Nil(t, cfg.keychain)
 		assert.False(t, cfg.insecureFileFallback)
-		assert.Empty(t, cfg.insecureFileFallbackPath)
+		assert.Empty(t, cfg.insecureFilePath)
 	})
 }
 
@@ -58,7 +59,7 @@ func TestBuildKeychainConfigWithOptions(t *testing.T) {
 	t.Run("with insecure file fallback", func(t *testing.T) {
 		cfg := buildKeychainConfig([]KeychainOption{WithInsecureFileFallback()})
 		assert.True(t, cfg.insecureFileFallback)
-		assert.Empty(t, cfg.insecureFileFallbackPath)
+		assert.Empty(t, cfg.insecureFilePath)
 	})
 
 	t.Run("with insecure file fallback path implies fallback", func(t *testing.T) {
@@ -66,7 +67,16 @@ func TestBuildKeychainConfigWithOptions(t *testing.T) {
 			WithInsecureFileFallbackPath("/tmp/creds.json"),
 		})
 		assert.True(t, cfg.insecureFileFallback)
-		assert.Equal(t, "/tmp/creds.json", cfg.insecureFileFallbackPath)
+		assert.Equal(t, "/tmp/creds.json", cfg.insecureFilePath)
+	})
+
+	t.Run("with insecure file store bypasses keychain", func(t *testing.T) {
+		cfg := buildKeychainConfig([]KeychainOption{
+			WithInsecureFileStore("/tmp/creds.json", 0o644),
+		})
+		assert.True(t, cfg.insecureFileOnly)
+		assert.Equal(t, "/tmp/creds.json", cfg.insecureFilePath)
+		assert.Equal(t, os.FileMode(0o644), cfg.insecureFileMode)
 	})
 }
 

--- a/cloud/keychain_resolver_test.go
+++ b/cloud/keychain_resolver_test.go
@@ -1,6 +1,7 @@
 package cloud
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -241,5 +242,36 @@ func TestKeychainCredentialResolver_ChainIntegration(t *testing.T) {
 		assert.Equal(t, "sk-keychain-key", apiKey)
 		tenant, _ := creds.GetTenantDomain()
 		assert.Equal(t, "keychain-tenant", tenant)
+	})
+}
+
+func TestKeychainCredentialResolver_InsecureFileStore(t *testing.T) {
+	t.Run("store and resolver roundtrip through forced file", func(t *testing.T) {
+		filePath := t.TempDir() + "/creds.json"
+		opts := []KeychainOption{
+			WithAppName("safedep-test-" + t.Name()),
+			WithInsecureFileStore(filePath, 0o644),
+		}
+
+		store, err := NewKeychainCredentialStore(opts...)
+		require.NoError(t, err)
+		defer func() { require.NoError(t, store.Close()) }()
+
+		require.NoError(t, store.SaveAPIKeyCredential("sk-file-key", "tenant-file"))
+
+		info, err := os.Stat(filePath)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o644), info.Mode().Perm())
+
+		resolver, err := NewKeychainCredentialResolver(CredentialTypeAPIKey, opts...)
+		require.NoError(t, err)
+		defer func() { require.NoError(t, resolver.Close()) }()
+
+		creds, err := resolver.Resolve()
+		require.NoError(t, err)
+
+		apiKey, err := creds.GetAPIKey()
+		require.NoError(t, err)
+		assert.Equal(t, "sk-file-key", apiKey)
 	})
 }

--- a/cloud/keychain_store.go
+++ b/cloud/keychain_store.go
@@ -113,7 +113,9 @@ func resolveKeychain(cfg keychainConfig) (keychain.Keychain, bool, error) {
 	kc, err := keychain.New(keychain.Config{
 		AppName:              cfg.appName,
 		InsecureFileFallback: cfg.insecureFileFallback,
-		FilePath:             cfg.insecureFileFallbackPath,
+		InsecureFileOnly:     cfg.insecureFileOnly,
+		FilePath:             cfg.insecureFilePath,
+		FileMode:             cfg.insecureFileMode,
 	})
 	if err != nil {
 		return nil, false, fmt.Errorf("cloud: failed to create keychain: %w", err)

--- a/keychain/file_provider.go
+++ b/keychain/file_provider.go
@@ -25,9 +25,10 @@ type fileStore struct {
 type fileProvider struct {
 	mu       sync.RWMutex
 	filePath string
+	mode     os.FileMode
 }
 
-func newFileProvider(appName, filePath string) (*fileProvider, error) {
+func newFileProvider(appName, filePath string, mode os.FileMode) (*fileProvider, error) {
 	if filePath == "" {
 		configDir, err := localConfigDir()
 		if err != nil {
@@ -36,10 +37,15 @@ func newFileProvider(appName, filePath string) (*fileProvider, error) {
 		filePath = filepath.Join(configDir, appName, "creds.json")
 	}
 
+	if mode == 0 {
+		mode = filePermissions
+	}
+
 	log.Warnf("Using insecure plaintext credential storage at %s", filePath)
 
 	return &fileProvider{
 		filePath: filePath,
+		mode:     mode,
 	}, nil
 }
 
@@ -156,7 +162,7 @@ func (f *fileProvider) writeStore(store *fileStore) error {
 		return fmt.Errorf("keychain: failed to close temp file: %w", err)
 	}
 
-	if err := os.Chmod(tmpPath, filePermissions); err != nil {
+	if err := os.Chmod(tmpPath, f.mode); err != nil {
 		return fmt.Errorf("keychain: failed to set file permissions: %w", err)
 	}
 

--- a/keychain/file_provider_test.go
+++ b/keychain/file_provider_test.go
@@ -15,7 +15,7 @@ func newTestFileProvider(t *testing.T) *fileProvider {
 	t.Helper()
 	tmpDir := t.TempDir()
 	filePath := filepath.Join(tmpDir, "test-app", "creds.json")
-	fp, err := newFileProvider("test-app", filePath)
+	fp, err := newFileProvider("test-app", filePath, 0)
 	require.NoError(t, err)
 	return fp
 }
@@ -144,7 +144,7 @@ func TestFileProviderFilePermissions(t *testing.T) {
 }
 
 func TestFileProviderDefaultPath(t *testing.T) {
-	fp, err := newFileProvider("myapp", "")
+	fp, err := newFileProvider("myapp", "", 0)
 	require.NoError(t, err)
 
 	configDir, err := localConfigDir()

--- a/keychain/keychain.go
+++ b/keychain/keychain.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 )
 
 var ErrNotFound = errors.New("keychain: secret not found")
@@ -23,9 +24,18 @@ type Config struct {
 	// when the OS keychain is unavailable.
 	InsecureFileFallback bool
 
+	// InsecureFileOnly uses plaintext JSON file storage directly,
+	// bypassing the OS keychain even when it is available. Takes
+	// precedence over InsecureFileFallback.
+	InsecureFileOnly bool
+
 	// FilePath overrides the default file path for the insecure
 	// file provider. Defaults to $HOME/.config/<AppName>/creds.json.
 	FilePath string
+
+	// FileMode sets the credential file permissions. Defaults to 0600.
+	// Ignored unless file storage is used.
+	FileMode os.FileMode
 }
 
 type Keychain interface {
@@ -51,16 +61,18 @@ func New(config Config) (Keychain, error) {
 		return nil, fmt.Errorf("keychain: AppName is required")
 	}
 
-	p, err := newKeyringProvider(config.AppName)
-	if err == nil {
-		return &keychainImpl{p: p}, nil
+	if !config.InsecureFileOnly {
+		p, err := newKeyringProvider(config.AppName)
+		if err == nil {
+			return &keychainImpl{p: p}, nil
+		}
+
+		if !config.InsecureFileFallback {
+			return nil, fmt.Errorf("keychain: OS keychain unavailable: %w", err)
+		}
 	}
 
-	if !config.InsecureFileFallback {
-		return nil, fmt.Errorf("keychain: OS keychain unavailable: %w", err)
-	}
-
-	fp, err := newFileProvider(config.AppName, config.FilePath)
+	fp, err := newFileProvider(config.AppName, config.FilePath, config.FileMode)
 	if err != nil {
 		return nil, fmt.Errorf("keychain: failed to create file provider: %w", err)
 	}

--- a/keychain/keychain_test.go
+++ b/keychain/keychain_test.go
@@ -2,6 +2,7 @@ package keychain
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -42,6 +43,77 @@ func TestNewWithInsecureFileFallback(t *testing.T) {
 
 	_, err = kc.Get(ctx, "token")
 	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestNewWithInsecureFileOnlyBypassesOSKeychain(t *testing.T) {
+	filePath := filepath.Join(t.TempDir(), "creds.json")
+
+	kc, err := New(Config{
+		AppName:          "test-app",
+		InsecureFileOnly: true,
+		FilePath:         filePath,
+	})
+	require.NoError(t, err)
+	defer func() { assert.NoError(t, kc.Close()) }()
+
+	ctx := context.Background()
+	require.NoError(t, kc.Set(ctx, "token", &Secret{Value: "force-file-secret"}))
+
+	secret, err := kc.Get(ctx, "token")
+	require.NoError(t, err)
+	assert.Equal(t, "force-file-secret", secret.Value)
+
+	// The secret must be in the file, proving the OS keychain was bypassed
+	// even on platforms where it is available.
+	data, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "force-file-secret")
+}
+
+func TestFileMode(t *testing.T) {
+	t.Run("custom mode applied and preserved across rewrites", func(t *testing.T) {
+		filePath := filepath.Join(t.TempDir(), "creds.json")
+
+		kc, err := New(Config{
+			AppName:          "test-app",
+			InsecureFileOnly: true,
+			FilePath:         filePath,
+			FileMode:         0o644,
+		})
+		require.NoError(t, err)
+		defer func() { assert.NoError(t, kc.Close()) }()
+
+		ctx := context.Background()
+		require.NoError(t, kc.Set(ctx, "k1", &Secret{Value: "v1"}))
+
+		info, err := os.Stat(filePath)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o644), info.Mode().Perm())
+
+		require.NoError(t, kc.Delete(ctx, "k1"))
+
+		info, err = os.Stat(filePath)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o644), info.Mode().Perm())
+	})
+
+	t.Run("defaults to 0600", func(t *testing.T) {
+		filePath := filepath.Join(t.TempDir(), "creds.json")
+
+		kc, err := New(Config{
+			AppName:          "test-app",
+			InsecureFileOnly: true,
+			FilePath:         filePath,
+		})
+		require.NoError(t, err)
+		defer func() { assert.NoError(t, kc.Close()) }()
+
+		require.NoError(t, kc.Set(context.Background(), "k1", &Secret{Value: "v1"}))
+
+		info, err := os.Stat(filePath)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+	})
 }
 
 func TestNewWithoutFallbackFailsOnUnsupportedPlatform(t *testing.T) {


### PR DESCRIPTION
## Problem

The plaintext file provider is only reachable as a *fallback* — `keychain.New` always probes the OS keyring first and uses the file only when the keyring is unavailable. It also hardcodes `0600` and re-applies it on **every** write.

This blocks a downstream PMG feature (`pmg cloud login --system`) that needs a deterministic, shared credential file at `/etc/safedep/pmg/creds.json`, readable by every user on a machine / Docker image:

- On a host with a working keyring (desktop Linux as root), credentials would silently land in the keyring — per-user encrypted storage no other user can read — instead of the system file.
- Even with a chmod after creation, the next write (re-login, `Clear()`) would snap the file back to `0600` and break resolution for all other users.

## Change

- `keychain.Config.InsecureFileOnly` — use plaintext file storage directly, bypassing the OS keychain even when available. Sibling of the existing `InsecureFileFallback`; takes precedence over it. Both paths share the same file-provider construction.
- `keychain.Config.FileMode` — credential file permissions, applied on every write so a custom mode (e.g. `0644`) survives rewrites. Zero value keeps the `0600` default.
- `cloud.WithInsecureFileStore(path, mode)` — exposes both through the existing option plumbing; works for `NewKeychainCredentialStore` and `NewKeychainCredentialResolver` since they share `resolveKeychain`.
- Internal `cloud.keychainConfig` fields renamed (`insecureFileFallbackPath` → `insecureFilePath` etc.) since the path/mode now serve both the fallback and file-only options.

Default behavior is unchanged: keyring-first, fallback only if enabled, `0600`.

## Tests

- File-only mode stores to the file even when the OS keychain is available (asserted by reading the file content — meaningful on macOS/desktop CI where the keyring works).
- `FileMode` applied on create **and preserved across rewrites** (set → delete → stat); default stays `0600`.
- Option mapping in `buildKeychainConfig`; store → resolver roundtrip through the forced file with a permissions check.