### PR TITLE
feat(endpointsync): add emit-only EventEmitterClient

### DIFF
--- a/cloud/endpointsync/client.go
+++ b/cloud/endpointsync/client.go
@@ -57,30 +57,21 @@ type eventWriter struct {
 //   - identity: resolves endpoint identity (identifier + metadata) for sync requests.
 //   - opts: optional overrides (WithBatchSize, WithMaxPending, WithWALPath).
 func NewSyncClient(toolName string, toolVersion string, transport EventTransport, identity EndpointIdentityResolver, opts ...SyncOption) (*SyncClient, error) {
-	writer, cfg, err := newEventWriter(toolName, toolVersion, opts...)
-	if err != nil {
-		return nil, err
-	}
-
 	if transport == nil {
-		if closeErr := writer.Close(); closeErr != nil {
-			log.Warnf("endpointsync: failed to close WAL after client setup error: %v", closeErr)
-		}
 		return nil, ErrMissingTransport
 	}
 	if identity == nil {
-		if closeErr := writer.Close(); closeErr != nil {
-			log.Warnf("endpointsync: failed to close WAL after client setup error: %v", closeErr)
-		}
 		return nil, ErrMissingIdentity
 	}
 
 	endpointIdentity, err := identity.Resolve()
 	if err != nil {
-		if closeErr := writer.Close(); closeErr != nil {
-			log.Warnf("endpointsync: failed to close WAL after client setup error: %v", closeErr)
-		}
 		return nil, fmt.Errorf("endpointsync: failed to resolve endpoint identity: %w", err)
+	}
+
+	writer, cfg, err := newEventWriter(toolName, toolVersion, opts...)
+	if err != nil {
+		return nil, err
 	}
 
 	breaker := gobreaker.NewCircuitBreaker[*servicev1.SyncEventsResponse](gobreaker.Settings{

--- a/cloud/endpointsync/client.go
+++ b/cloud/endpointsync/client.go
@@ -28,13 +28,22 @@ func isValidToolName(name string) bool {
 
 // SyncClient handles reliable event sync to SafeDep Cloud.
 type SyncClient struct {
+	*eventWriter
+	transport EventTransport
+	identity  *controltowerv1.EndpointIdentity
+	config    *syncConfig
+	breaker   *gobreaker.CircuitBreaker[*servicev1.SyncEventsResponse]
+}
+
+// EventEmitterClient creates ToolEvents and persists them to the local WAL.
+type EventEmitterClient struct {
+	*eventWriter
+}
+
+type eventWriter struct {
 	toolName    string
 	toolVersion string
-	transport   EventTransport
-	identity    *controltowerv1.EndpointIdentity
-	config      *syncConfig
 	store       *wal
-	breaker     *gobreaker.CircuitBreaker[*servicev1.SyncEventsResponse]
 }
 
 // NewSyncClient creates a new sync client.
@@ -48,38 +57,31 @@ type SyncClient struct {
 //   - identity: resolves endpoint identity (identifier + metadata) for sync requests.
 //   - opts: optional overrides (WithBatchSize, WithMaxPending, WithWALPath).
 func NewSyncClient(toolName string, toolVersion string, transport EventTransport, identity EndpointIdentityResolver, opts ...SyncOption) (*SyncClient, error) {
-	if !isValidToolName(toolName) {
-		return nil, fmt.Errorf("endpointsync: invalid tool name %q: must be non-empty, alphanumeric with hyphens only", toolName)
+	writer, cfg, err := newEventWriter(toolName, toolVersion, opts...)
+	if err != nil {
+		return nil, err
 	}
-	if toolVersion == "" {
-		return nil, fmt.Errorf("endpointsync: tool version is required")
-	}
+
 	if transport == nil {
+		if closeErr := writer.Close(); closeErr != nil {
+			log.Warnf("endpointsync: failed to close WAL after client setup error: %v", closeErr)
+		}
 		return nil, ErrMissingTransport
 	}
 	if identity == nil {
+		if closeErr := writer.Close(); closeErr != nil {
+			log.Warnf("endpointsync: failed to close WAL after client setup error: %v", closeErr)
+		}
 		return nil, ErrMissingIdentity
 	}
 
 	endpointIdentity, err := identity.Resolve()
 	if err != nil {
+		if closeErr := writer.Close(); closeErr != nil {
+			log.Warnf("endpointsync: failed to close WAL after client setup error: %v", closeErr)
+		}
 		return nil, fmt.Errorf("endpointsync: failed to resolve endpoint identity: %w", err)
 	}
-
-	cfg := defaultSyncConfig(toolName)
-	for _, opt := range opts {
-		opt(cfg)
-	}
-
-	if err := os.MkdirAll(filepath.Dir(cfg.walPath), 0o755); err != nil {
-		return nil, fmt.Errorf("%w: failed to create WAL directory: %w", ErrWALOpen, err)
-	}
-
-	store, err := openWAL(cfg.walPath)
-	if err != nil {
-		return nil, err
-	}
-	store.maxPending = cfg.maxPending
 
 	breaker := gobreaker.NewCircuitBreaker[*servicev1.SyncEventsResponse](gobreaker.Settings{
 		Name:        fmt.Sprintf("endpointsync-%s", toolName),
@@ -94,28 +96,70 @@ func NewSyncClient(toolName string, toolVersion string, transport EventTransport
 	})
 
 	return &SyncClient{
-		toolName:    toolName,
-		toolVersion: toolVersion,
+		eventWriter: writer,
 		transport:   transport,
 		identity:    endpointIdentity,
 		config:      cfg,
-		store:       store,
 		breaker:     breaker,
 	}, nil
 }
 
+// NewEventEmitterClient creates a new emit-only client.
+//
+// The client validates tool metadata, opens the local WAL, and requires no
+// transport or endpoint identity. WithBatchSize is accepted because SyncOption
+// is shared with SyncClient, but it has no effect on emit-only behavior.
+func NewEventEmitterClient(toolName string, toolVersion string, opts ...SyncOption) (*EventEmitterClient, error) {
+	writer, _, err := newEventWriter(toolName, toolVersion, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &EventEmitterClient{eventWriter: writer}, nil
+}
+
+func newEventWriter(toolName string, toolVersion string, opts ...SyncOption) (*eventWriter, *syncConfig, error) {
+	if !isValidToolName(toolName) {
+		return nil, nil, fmt.Errorf("endpointsync: invalid tool name %q: must be non-empty, alphanumeric with hyphens only", toolName)
+	}
+	if toolVersion == "" {
+		return nil, nil, fmt.Errorf("endpointsync: tool version is required")
+	}
+
+	cfg := defaultSyncConfig(toolName)
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(cfg.walPath), 0o755); err != nil {
+		return nil, nil, fmt.Errorf("%w: failed to create WAL directory: %w", ErrWALOpen, err)
+	}
+
+	store, err := openWAL(cfg.walPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	store.maxPending = cfg.maxPending
+
+	return &eventWriter{
+		toolName:    toolName,
+		toolVersion: toolVersion,
+		store:       store,
+	}, cfg, nil
+}
+
 // NewEvent creates a ToolEvent with pre-filled fields.
-func (c *SyncClient) NewEvent() (*servicev1.ToolEvent, error) {
+func (w *eventWriter) NewEvent() (*servicev1.ToolEvent, error) {
 	return &servicev1.ToolEvent{
 		EventId:     uuid.New().String(),
-		ToolName:    c.toolName,
-		ToolVersion: c.toolVersion,
+		ToolName:    w.toolName,
+		ToolVersion: w.toolVersion,
 		Timestamp:   timestamppb.Now(),
 	}, nil
 }
 
 // Emit persists a ToolEvent to the local WAL.
-func (c *SyncClient) Emit(ctx context.Context, event *servicev1.ToolEvent) error {
+func (w *eventWriter) Emit(ctx context.Context, event *servicev1.ToolEvent) error {
 	if event == nil {
 		return fmt.Errorf("endpointsync: event must not be nil")
 	}
@@ -132,7 +176,12 @@ func (c *SyncClient) Emit(ctx context.Context, event *servicev1.ToolEvent) error
 		return fmt.Errorf("endpointsync: failed to marshal event: %w", err)
 	}
 
-	return c.store.insert(event.GetEventId(), payload)
+	return w.store.insert(event.GetEventId(), payload)
+}
+
+// Close releases the WAL.
+func (w *eventWriter) Close() error {
+	return w.store.close()
 }
 
 // Sync delivers pending events from the WAL to the server.
@@ -245,7 +294,7 @@ func (c *SyncClient) Sync(ctx context.Context) (int, error) {
 // Close releases resources.
 func (c *SyncClient) Close() error {
 	var errs []error
-	if err := c.store.close(); err != nil {
+	if err := c.eventWriter.Close(); err != nil {
 		errs = append(errs, fmt.Errorf("failed to close WAL: %w", err))
 	}
 	if c.transport != nil {

--- a/cloud/endpointsync/client_test.go
+++ b/cloud/endpointsync/client_test.go
@@ -45,6 +45,33 @@ func TestNewSyncClient(t *testing.T) {
 	})
 }
 
+func TestNewEventEmitterClient(t *testing.T) {
+	t.Run("valid config creates client without transport or identity", func(t *testing.T) {
+		client, err := NewEventEmitterClient("test-tool", "1.0.0",
+			WithWALPath(filepath.Join(t.TempDir(), "test.db")),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, client)
+		require.NoError(t, client.Close())
+	})
+
+	t.Run("invalid tool name returns error", func(t *testing.T) {
+		_, err := NewEventEmitterClient("../test", "1.0.0",
+			WithWALPath(filepath.Join(t.TempDir(), "test.db")),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "endpointsync: invalid tool name")
+	})
+
+	t.Run("empty tool version returns error", func(t *testing.T) {
+		_, err := NewEventEmitterClient("test-tool", "",
+			WithWALPath(filepath.Join(t.TempDir(), "test.db")),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "endpointsync: tool version is required")
+	})
+}
+
 func TestNewEvent(t *testing.T) {
 	client := newTestClient(t, &mockTransport{})
 
@@ -58,6 +85,68 @@ func TestNewEvent(t *testing.T) {
 
 	event2, _ := client.NewEvent()
 	assert.NotEqual(t, event.GetEventId(), event2.GetEventId())
+}
+
+func TestEventEmitterClientNewEvent(t *testing.T) {
+	client, err := NewEventEmitterClient("test-tool", "1.0.0",
+		WithWALPath(filepath.Join(t.TempDir(), "test.db")),
+	)
+	require.NoError(t, err)
+	defer func() { _ = client.Close() }()
+
+	event, err := client.NewEvent()
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, event.GetEventId())
+	assert.Equal(t, "test-tool", event.GetToolName())
+	assert.Equal(t, "1.0.0", event.GetToolVersion())
+	assert.NotNil(t, event.GetTimestamp())
+
+	event2, err := client.NewEvent()
+	require.NoError(t, err)
+	assert.NotEqual(t, event.GetEventId(), event2.GetEventId())
+}
+
+func TestEventEmitterClientEmitPersistsToWAL(t *testing.T) {
+	walPath := filepath.Join(t.TempDir(), "test.db")
+	emitter, err := NewEventEmitterClient("test-tool", "1.0.0", WithWALPath(walPath))
+	require.NoError(t, err)
+
+	event, err := emitter.NewEvent()
+	require.NoError(t, err)
+	event.PmgEvent = &controltowerv1.PmgEvent{
+		EventType: controltowerv1.PmgEventType_PMG_EVENT_TYPE_SESSION_SUMMARY,
+		SessionSummary: &controltowerv1.PmgSessionSummary{
+			TotalAnalyzed: 1,
+		},
+	}
+	require.NoError(t, emitter.Emit(context.Background(), event))
+	require.NoError(t, emitter.Close())
+
+	var uploaded []*servicev1.ToolEvent
+	transport := &mockTransport{
+		sendFunc: func(ctx context.Context, req *servicev1.SyncEventsRequest) (*servicev1.SyncEventsResponse, error) {
+			uploaded = append(uploaded, req.GetEvents()...)
+			ids := make([]string, 0, len(req.GetEvents()))
+			for _, e := range req.GetEvents() {
+				ids = append(ids, e.GetEventId())
+			}
+			return &servicev1.SyncEventsResponse{ConfirmedEventIds: ids}, nil
+		},
+	}
+
+	syncClient, err := NewSyncClient("test-tool", "1.0.0", transport,
+		NewEndpointIdentityResolver(WithEndpointID("test-endpoint")),
+		WithWALPath(walPath),
+	)
+	require.NoError(t, err)
+	defer func() { _ = syncClient.Close() }()
+
+	synced, err := syncClient.Sync(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, synced)
+	require.Len(t, uploaded, 1)
+	assert.Equal(t, event.GetEventId(), uploaded[0].GetEventId())
 }
 
 func TestEmitAndSync(t *testing.T) {
@@ -436,6 +525,34 @@ func TestEmitWALFull(t *testing.T) {
 	}
 
 	event, _ := client.NewEvent()
+	event.PmgEvent = &controltowerv1.PmgEvent{
+		EventType:      controltowerv1.PmgEventType_PMG_EVENT_TYPE_SESSION_SUMMARY,
+		SessionSummary: &controltowerv1.PmgSessionSummary{},
+	}
+	err = client.Emit(context.Background(), event)
+	assert.ErrorIs(t, err, ErrWALFull)
+}
+
+func TestEventEmitterClientEmitWALFull(t *testing.T) {
+	client, err := NewEventEmitterClient("test", "1.0.0",
+		WithWALPath(filepath.Join(t.TempDir(), "test.db")),
+		WithMaxPending(2),
+	)
+	require.NoError(t, err)
+	defer func() { _ = client.Close() }()
+
+	for i := 0; i < 2; i++ {
+		event, err := client.NewEvent()
+		require.NoError(t, err)
+		event.PmgEvent = &controltowerv1.PmgEvent{
+			EventType:      controltowerv1.PmgEventType_PMG_EVENT_TYPE_SESSION_SUMMARY,
+			SessionSummary: &controltowerv1.PmgSessionSummary{},
+		}
+		require.NoError(t, client.Emit(context.Background(), event))
+	}
+
+	event, err := client.NewEvent()
+	require.NoError(t, err)
 	event.PmgEvent = &controltowerv1.PmgEvent{
 		EventType:      controltowerv1.PmgEventType_PMG_EVENT_TYPE_SESSION_SUMMARY,
 		SessionSummary: &controltowerv1.PmgSessionSummary{},


### PR DESCRIPTION
## Summary
- Extract a shared `eventWriter` from `SyncClient` that owns tool metadata (name/version) and the local WAL, providing `NewEvent`, `Emit`, and `Close`.
- Add `NewEventEmitterClient`, an emit-only client that creates and persists `ToolEvent`s to the WAL without requiring a transport or endpoint identity — for tools that only emit events locally and leave syncing to a separate process.
- `NewSyncClient` now closes the WAL if setup fails after the WAL was opened (missing transport/identity, identity resolution failure), instead of leaking the handle.

## Test plan
- [x] `go test ./cloud/endpointsync/` passes
- New tests cover emitter construction/validation, `NewEvent` field pre-fill, emit → WAL persistence picked up by a `SyncClient` on the same WAL path, and `ErrWALFull` enforcement on the emit-only client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)