### PR TITLE
feat(storage): PresignedStorage interface + S3 pre-signed GET URLs (#135)

### DIFF
--- a/storage/s3.go
+++ b/storage/s3.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
@@ -43,7 +44,10 @@ func WithS3Client(client *s3.Client) s3StorageDriverOpts {
 	}
 }
 
-var _ StorageWriter = (*s3StorageDriver)(nil)
+var (
+	_ StorageWriter    = (*s3StorageDriver)(nil)
+	_ PresignedStorage = (*s3StorageDriver)(nil)
+)
 
 // NewS3StorageDriver constructs an S3-backed StorageWriter.
 //
@@ -202,6 +206,32 @@ func (w *s3Writer) Close() error {
 	}
 
 	return nil
+}
+
+// PresignedGetURL returns a pre-signed S3 GET URL for the object at key, valid
+// for ttl, and the time at which the URL expires (ttl from now). Pre-signing is
+// a local operation — no network round-trip — and does NOT verify that the
+// object exists: an absent key yields a URL that 404s on use, so callers that
+// need existence guarantees must check separately.
+func (d *s3StorageDriver) PresignedGetURL(key string, ttl time.Duration) (string, time.Time, error) {
+	if ttl <= 0 {
+		return "", time.Time{}, fmt.Errorf("s3 storage adapter: presign ttl must be positive")
+	}
+
+	keyName, err := d.prefix(key)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("s3 storage adapter: failed to prefix key: %w", err)
+	}
+
+	req, err := s3.NewPresignClient(d.client).PresignGetObject(d.ctx, &s3.GetObjectInput{
+		Bucket: aws.String(d.config.BucketName),
+		Key:    aws.String(keyName),
+	}, s3.WithPresignExpires(ttl))
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("s3 storage adapter: failed to presign get object: %w", err)
+	}
+
+	return req.URL, time.Now().Add(ttl), nil
 }
 
 func (d *s3StorageDriver) prefix(key string) (string, error) {

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -231,7 +231,7 @@ func (d *s3StorageDriver) PresignedGetURL(key string, ttl time.Duration) (string
 		return "", time.Time{}, fmt.Errorf("s3 storage adapter: failed to presign get object: %w", err)
 	}
 
-	return req.URL, time.Now().Add(ttl), nil
+	return req.URL, time.Now().UTC().Add(ttl), nil
 }
 
 func (d *s3StorageDriver) prefix(key string) (string, error) {

--- a/storage/s3_test.go
+++ b/storage/s3_test.go
@@ -9,9 +9,11 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/assert"
@@ -67,6 +69,43 @@ func TestNewS3StorageDriverRequiresBucket(t *testing.T) {
 	_, err := NewS3StorageDriver(S3StorageDriverConfig{})
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "bucket name is required")
+}
+
+// TestS3StorageDriverPresignedGetURL exercises pre-signing offline: SigV4
+// query-signing is a local computation, so static credentials + a region are
+// enough — no S3 endpoint needed.
+func TestS3StorageDriverPresignedGetURL(t *testing.T) {
+	client := s3.New(s3.Options{
+		Region:      "us-east-1",
+		Credentials: credentials.NewStaticCredentialsProvider("AKIAEXAMPLE", "secretEXAMPLE", ""),
+	})
+	driver, err := NewS3StorageDriver(
+		S3StorageDriverConfig{BucketName: "snap-bucket"},
+		WithS3Client(client),
+	)
+	require.NoError(t, err)
+
+	t.Run("mints a signed URL carrying the key and ttl", func(t *testing.T) {
+		notBefore := time.Now()
+		url, expiresAt, err := driver.PresignedGetURL("/snapshots/2026-07-31/reports.jsonl.gz", 5*time.Minute)
+		require.NoError(t, err)
+
+		assert.Contains(t, url, "snap-bucket")
+		assert.Contains(t, url, "snapshots/2026-07-31/reports.jsonl.gz")
+		assert.Contains(t, url, "X-Amz-Signature=")
+		assert.Contains(t, url, "X-Amz-Expires=300")
+		assert.WithinDuration(t, notBefore.Add(5*time.Minute), expiresAt, 2*time.Second)
+	})
+
+	t.Run("rejects a non-positive ttl", func(t *testing.T) {
+		_, _, err := driver.PresignedGetURL("k", 0)
+		assert.Error(t, err)
+	})
+
+	t.Run("rejects an empty key", func(t *testing.T) {
+		_, _, err := driver.PresignedGetURL("///", time.Minute)
+		assert.Error(t, err)
+	})
 }
 
 // TestS3StorageDriver_Integration exercises Put/Get/Writer against a real

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -2,7 +2,10 @@
 // general purpose storage system.
 package storage
 
-import "io"
+import (
+	"io"
+	"time"
+)
 
 // Storage is a simple storage interface with read and write operations.
 // This interface should be extended to support more capable contracts
@@ -17,4 +20,17 @@ type StorageWriter interface {
 	Storage
 
 	Writer(key string) (io.WriteCloser, error)
+}
+
+// PresignedStorage is a Storage that can mint short-TTL pre-signed download
+// URLs for its objects, letting callers hand out time-limited read access
+// without proxying bytes or exposing storage keys. Not every backend supports
+// this (the local filesystem driver does not); S3 is the first implementation.
+type PresignedStorage interface {
+	Storage
+
+	// PresignedGetURL returns a pre-signed URL that grants read access to the
+	// object at key for ttl, together with the time the URL expires. ttl must
+	// be positive.
+	PresignedGetURL(key string, ttl time.Duration) (url string, expiresAt time.Time, err error)
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -30,7 +30,10 @@ type PresignedStorage interface {
 	Storage
 
 	// PresignedGetURL returns a pre-signed URL that grants read access to the
-	// object at key for ttl, together with the time the URL expires. ttl must
-	// be positive.
+	// object at key for ttl, together with the (UTC) time the URL expires. key
+	// must be non-empty and ttl must be positive. Pre-signing does NOT verify
+	// that the object exists — a missing key still yields a URL, which then
+	// 404s on use — so callers that need an existence guarantee must check
+	// separately.
 	PresignedGetURL(key string, ttl time.Duration) (url string, expiresAt time.Time, err error)
 }


### PR DESCRIPTION
## What

Adds `PresignedStorage`, an extension of `Storage` that mints short-TTL
pre-signed download URLs, and implements it on the S3 driver.

```go
type PresignedStorage interface {
	Storage
	PresignedGetURL(key string, ttl time.Duration) (url string, expiresAt time.Time, err error)
}
```

- S3 impl uses `s3.NewPresignClient(...).PresignGetObject(..., s3.WithPresignExpires(ttl))` — SigV4 query signing, a **local** operation (no network round-trip).
- Mirrors the `StorageWriter` extension pattern. `fs`/`gcs`/`r2` drivers do **not** implement it yet — S3 is the first.
- Pre-signing does **not** verify object existence: an absent key yields a URL that 404s on use (documented on the method).

## Testing

Offline unit test (static credentials, no S3 endpoint — presigning is local) asserts the URL carries the bucket/key + `X-Amz-Signature` / `X-Amz-Expires=300`, plus `ttl <= 0` and empty-key rejection. `go build` / `go vet` / `go test ./storage/` clean.

## Why

Unblocks control-tower's Threat Intel snapshot downloads (#1119): `GetSnapshotDownloadUrl` pre-signs snapshot artifacts **exclusively** through this abstraction — no AWS SDK usage in control-tower.

Closes #135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
