### PR TITLE
feat(storage): thread context through PresignedStorage.PresignedGetURL

### DIFF
--- a/storage/s3.go
+++ b/storage/s3.go
@@ -209,11 +209,13 @@ func (w *s3Writer) Close() error {
 }
 
 // PresignedGetURL returns a pre-signed S3 GET URL for the object at key, valid
-// for ttl, and the time at which the URL expires (ttl from now). Pre-signing is
-// a local operation — no network round-trip — and does NOT verify that the
-// object exists: an absent key yields a URL that 404s on use, so callers that
-// need existence guarantees must check separately.
-func (d *s3StorageDriver) PresignedGetURL(key string, ttl time.Duration) (string, time.Time, error) {
+// for ttl, and the time at which the URL expires (ttl from now). ctx bounds the
+// signing call so a caller can cancel or deadline it. Pre-signing is normally a
+// local operation — no network round-trip — but the SDK may consult the
+// credential-provider chain / KMS; it does NOT verify that the object exists: an
+// absent key yields a URL that 404s on use, so callers that need existence
+// guarantees must check separately.
+func (d *s3StorageDriver) PresignedGetURL(ctx context.Context, key string, ttl time.Duration) (string, time.Time, error) {
 	if ttl <= 0 {
 		return "", time.Time{}, fmt.Errorf("s3 storage adapter: presign ttl must be positive")
 	}
@@ -223,7 +225,7 @@ func (d *s3StorageDriver) PresignedGetURL(key string, ttl time.Duration) (string
 		return "", time.Time{}, fmt.Errorf("s3 storage adapter: failed to prefix key: %w", err)
 	}
 
-	req, err := s3.NewPresignClient(d.client).PresignGetObject(d.ctx, &s3.GetObjectInput{
+	req, err := s3.NewPresignClient(d.client).PresignGetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String(d.config.BucketName),
 		Key:    aws.String(keyName),
 	}, s3.WithPresignExpires(ttl))

--- a/storage/s3_test.go
+++ b/storage/s3_test.go
@@ -106,6 +106,37 @@ func TestS3StorageDriverPresignedGetURL(t *testing.T) {
 		_, _, err := driver.PresignedGetURL(context.Background(), "///", time.Minute)
 		assert.Error(t, err)
 	})
+
+	// Regression guard for the ctx parameter: signing with static credentials
+	// is a purely local computation that never consults the context, so
+	// cancellation only bites where the SDK does I/O — the credential provider.
+	// A context-aware provider proves the caller's context is actually threaded
+	// into the presign call; if a future change swapped it back for a background
+	// context, the provider would never observe the cancellation and this would
+	// fail.
+	t.Run("propagates a cancelled context to the credential provider", func(t *testing.T) {
+		ctxClient := s3.New(s3.Options{
+			Region: "us-east-1",
+			Credentials: aws.CredentialsProviderFunc(func(ctx context.Context) (aws.Credentials, error) {
+				if err := ctx.Err(); err != nil {
+					return aws.Credentials{}, err
+				}
+				return aws.Credentials{AccessKeyID: "AKIAEXAMPLE", SecretAccessKey: "secretEXAMPLE"}, nil
+			}),
+		})
+		ctxDriver, err := NewS3StorageDriver(
+			S3StorageDriverConfig{BucketName: "snap-bucket"},
+			WithS3Client(ctxClient),
+		)
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, _, err = ctxDriver.PresignedGetURL(ctx, "snapshots/reports.jsonl.gz", time.Minute)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, context.Canceled)
+	})
 }
 
 // TestS3StorageDriver_Integration exercises Put/Get/Writer against a real

--- a/storage/s3_test.go
+++ b/storage/s3_test.go
@@ -87,7 +87,7 @@ func TestS3StorageDriverPresignedGetURL(t *testing.T) {
 
 	t.Run("mints a signed URL carrying the key and ttl", func(t *testing.T) {
 		notBefore := time.Now()
-		url, expiresAt, err := driver.PresignedGetURL("/snapshots/2026-07-31/reports.jsonl.gz", 5*time.Minute)
+		url, expiresAt, err := driver.PresignedGetURL(context.Background(), "/snapshots/2026-07-31/reports.jsonl.gz", 5*time.Minute)
 		require.NoError(t, err)
 
 		assert.Contains(t, url, "snap-bucket")
@@ -98,12 +98,12 @@ func TestS3StorageDriverPresignedGetURL(t *testing.T) {
 	})
 
 	t.Run("rejects a non-positive ttl", func(t *testing.T) {
-		_, _, err := driver.PresignedGetURL("k", 0)
+		_, _, err := driver.PresignedGetURL(context.Background(), "k", 0)
 		assert.Error(t, err)
 	})
 
 	t.Run("rejects an empty key", func(t *testing.T) {
-		_, _, err := driver.PresignedGetURL("///", time.Minute)
+		_, _, err := driver.PresignedGetURL(context.Background(), "///", time.Minute)
 		assert.Error(t, err)
 	})
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -3,6 +3,7 @@
 package storage
 
 import (
+	"context"
 	"io"
 	"time"
 )
@@ -31,9 +32,10 @@ type PresignedStorage interface {
 
 	// PresignedGetURL returns a pre-signed URL that grants read access to the
 	// object at key for ttl, together with the (UTC) time the URL expires. key
-	// must be non-empty and ttl must be positive. Pre-signing does NOT verify
-	// that the object exists — a missing key still yields a URL, which then
-	// 404s on use — so callers that need an existence guarantee must check
-	// separately.
-	PresignedGetURL(key string, ttl time.Duration) (url string, expiresAt time.Time, err error)
+	// must be non-empty and ttl must be positive. ctx bounds the signing call
+	// (credential-provider / KMS round-trips can block), so callers can cancel
+	// or apply a deadline. Pre-signing does NOT verify that the object exists —
+	// a missing key still yields a URL, which then 404s on use — so callers that
+	// need an existence guarantee must check separately.
+	PresignedGetURL(ctx context.Context, key string, ttl time.Duration) (url string, expiresAt time.Time, err error)
 }


### PR DESCRIPTION
Closes #138.

## Problem

`PresignedStorage.PresignedGetURL(key, ttl)` takes no `context.Context`. Presigning is usually a fast local SigV4 computation, but the SDK path can consult the credential-provider chain / KMS — under an outage that call can block a goroutine indefinitely with no way for the caller to cancel or apply a deadline.

Surfaced in review of safedep/control-tower#1160 (threatintel snapshot download URLs), where the service has a request context available but can't thread it in.

## Change

Add `ctx context.Context` as the first parameter of `PresignedGetURL` on both the `PresignedStorage` interface and the S3 driver, and pass it to `PresignGetObject` in place of the driver's stored background context.

- Only the S3 driver implements `PresignedStorage` (the R2 driver returns `*s3StorageDriver`, so it's covered too).
- Breaking interface change; the sole external consumer is control-tower's threatintel snapshot service, which will be updated in its dependency bump.

## Tests

Existing offline presign tests updated to pass `context.Background()`; `go test ./storage/` passes (SigV4 query-signing needs no live endpoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)