### PR TITLE
feat(tui): render actionable useful errors

### DIFF
--- a/docs/api-error.md
+++ b/docs/api-error.md
@@ -76,25 +76,26 @@ default:
 
 ## Rendering an error for the CLI
 
-`AsUsefulError` turns an error into a `UsefulError` with a code, a human message,
-and help text. When the error carries a typed reason, the presentation comes
-from a registered `ReasonPresentation`. When it does not, the generic per code
-converters handle it.
+`tui/errors.ErrorExit` renders a `UsefulError` as a code badge, human message,
+recovery action, and optional reference URL. Normal output hides diagnostic
+details. Verbose output includes them. When the error carries a typed reason,
+the presentation comes from a registered `ReasonPresentation`. When it does
+not, the generic per code converters handle it.
 
 ```go
-if useful, ok := usefulerror.AsUsefulError(err); ok {
-    fmt.Println(useful.HumanError())
-    fmt.Println(useful.Help())
-}
+import tuierrors "github.com/safedep/dry/tui/errors"
+
+tuierrors.ErrorExit(err)
 ```
 
 Applications can register their own presentation or override a default.
 
 ```go
 usefulerror.RegisterReason(errorv1.ErrorReason_ERROR_REASON_PROJECT_NOT_SCANNABLE, usefulerror.ReasonPresentation{
-    Code:       usefulerror.ErrBadRequest,
-    HumanError: "Project not scannable",
-    Help:       "Refresh the project source and retry.",
+    Code:         usefulerror.ErrBadRequest,
+    HumanError:   "Project not scannable",
+    Help:         "Grant the SafeDep GitHub App access to this repository, wait for project sync, then retry.",
+    ReferenceURL: "https://docs.safedep.io/governance/integrations/github",
 })
 ```
 

--- a/tui/errors/errors.go
+++ b/tui/errors/errors.go
@@ -8,9 +8,15 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/charmbracelet/lipgloss"
+	"github.com/safedep/dry/tui/icon"
 	"github.com/safedep/dry/tui/output"
 	"github.com/safedep/dry/tui/style"
+	"github.com/safedep/dry/tui/theme"
+	"github.com/safedep/dry/usefulerror"
 )
+
+const unavailableHelpText = "No additional help is available for this error."
 
 // ErrorExit prints the error (verbosity-aware) and exits with code 1.
 func ErrorExit(err error) {
@@ -28,6 +34,11 @@ func ErrorExitWithCode(err error, code int) {
 }
 
 func printError(err error) {
+	if usefulErr, ok := usefulerror.AsUsefulError(err); ok {
+		printUsefulError(usefulErr)
+		return
+	}
+
 	line := style.Error(err.Error())
 	_, _ = fmt.Fprintln(output.Stderr(), line)
 	if output.CurrentVerbosity() >= output.Verbose {
@@ -35,6 +46,44 @@ func printError(err error) {
 			_, _ = fmt.Fprintln(output.Stderr(), style.Faint("  caused by: "+cause.Error()))
 		})
 	}
+}
+
+func printUsefulError(err usefulerror.UsefulError) {
+	summary := fmt.Sprintf("%s %s",
+		style.Badge(theme.RoleCritical, err.Code()),
+		errorText(err.HumanError()))
+	_, _ = fmt.Fprintln(output.Stderr(), summary)
+
+	if help := err.Help(); help != "" && help != unavailableHelpText {
+		printUsefulErrorHint(help)
+	}
+	if referenceURL := err.ReferenceURL(); referenceURL != "" {
+		printUsefulErrorHint("Learn more: " + referenceURL)
+	}
+
+	if output.CurrentVerbosity() < output.Verbose {
+		return
+	}
+	if additionalHelp := err.AdditionalHelp(); additionalHelp != "" && additionalHelp != unavailableHelpText {
+		printUsefulErrorHint(additionalHelp)
+	}
+	if originalError := err.Error(); originalError != "" && originalError != err.HumanError() {
+		_, _ = fmt.Fprintln(output.Stderr(), style.Faint("  caused by: "+originalError))
+	}
+}
+
+func printUsefulErrorHint(message string) {
+	arrow, _ := theme.Default().Icons().Get(icon.KeyArrow)
+	prefix := arrow.Resolve(output.CurrentMode())
+	_, _ = fmt.Fprintln(output.Stderr(), style.Faint(prefix+" "+message))
+}
+
+func errorText(message string) string {
+	if output.CurrentMode() != output.Rich || !output.IsColorEnabled() {
+		return message
+	}
+	color, _ := theme.Default().Palette().ColorByRole(theme.RoleError)
+	return lipgloss.NewStyle().Bold(true).Foreground(color).Render(message)
 }
 
 // walkCauses traverses the error's wrap chain depth-first, invoking fn for

--- a/tui/errors/errors.go
+++ b/tui/errors/errors.go
@@ -9,8 +9,8 @@ import (
 	"os"
 
 	"github.com/charmbracelet/lipgloss"
-	"github.com/safedep/dry/tui/icon"
 	"github.com/safedep/dry/tui/output"
+	"github.com/safedep/dry/tui/section"
 	"github.com/safedep/dry/tui/style"
 	"github.com/safedep/dry/tui/theme"
 	"github.com/safedep/dry/usefulerror"
@@ -50,7 +50,7 @@ func printError(err error) {
 
 func printUsefulError(err usefulerror.UsefulError) {
 	summary := fmt.Sprintf("%s %s",
-		style.Badge(theme.RoleCritical, err.Code()),
+		style.Badge(theme.RoleError, err.Code()),
 		errorText(err.HumanError()))
 	_, _ = fmt.Fprintln(output.Stderr(), summary)
 
@@ -73,9 +73,7 @@ func printUsefulError(err usefulerror.UsefulError) {
 }
 
 func printUsefulErrorHint(message string) {
-	arrow, _ := theme.Default().Icons().Get(icon.KeyArrow)
-	prefix := arrow.Resolve(output.CurrentMode())
-	_, _ = fmt.Fprintln(output.Stderr(), style.Faint(prefix+" "+message))
+	_, _ = fmt.Fprintln(output.Stderr(), section.Hint(message))
 }
 
 func errorText(message string) string {

--- a/tui/errors/errors_test.go
+++ b/tui/errors/errors_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/safedep/dry/usefulerror"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/safedep/dry/tui/output"
@@ -69,4 +70,74 @@ func TestErrorExitVerboseShowsStack(t *testing.T) {
 		assert.Contains(t, buf.String(), "inner")
 	}()
 	ErrorExit(fmt.Errorf("wrapped: %w", errors.New("inner")))
+}
+
+func TestPrintErrorRendersUsefulError(t *testing.T) {
+	tests := []struct {
+		name        string
+		build       func() error
+		verbosity   output.Verbosity
+		want        string
+		notContains []string
+	}{
+		{
+			name: "normal output is structured and actionable",
+			build: func() error {
+				usefulErr := usefulerror.NewUsefulError().
+					WithCode(usefulerror.ErrBadRequest).
+					WithHumanError("Project not scannable").
+					WithHelp("Grant the SafeDep GitHub App access to this repository, wait for project sync, then retry.").
+					WithAdditionalHelp("rpc error: internal detail").
+					WithReferenceURL("https://docs.safedep.io/governance/integrations/github").
+					Wrap(errors.New("rpc error: internal detail"))
+				return fmt.Errorf("project scan create: %w", usefulErr)
+			},
+			verbosity: output.Normal,
+			want: "[bad_request] Project not scannable\n" +
+				"> Grant the SafeDep GitHub App access to this repository, wait for project sync, then retry.\n" +
+				"> Learn more: https://docs.safedep.io/governance/integrations/github\n",
+			notContains: []string{"rpc error", "No additional help is available"},
+		},
+		{
+			name: "missing optional fields do not render placeholders",
+			build: func() error {
+				return usefulerror.NewUsefulError().
+					WithCode(usefulerror.ErrBadRequest).
+					WithHumanError("Invalid request")
+			},
+			verbosity:   output.Normal,
+			want:        "[bad_request] Invalid request\n",
+			notContains: []string{"No additional help is available", "unknown"},
+		},
+		{
+			name: "verbose output includes diagnostic details",
+			build: func() error {
+				return usefulerror.NewUsefulError().
+					WithCode(usefulerror.ErrBadRequest).
+					WithHumanError("Invalid request").
+					WithHelp("Correct the request and retry.").
+					WithAdditionalHelp("field project_id is empty").
+					Wrap(errors.New("rpc error: invalid project_id"))
+			},
+			verbosity: output.Verbose,
+			want: "[bad_request] Invalid request\n" +
+				"> Correct the request and retry.\n" +
+				"> field project_id is empty\n" +
+				"  caused by: rpc error: invalid project_id\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := setupErrorTest(t)
+			output.SetVerbosity(tt.verbosity)
+
+			printError(tt.build())
+
+			assert.Equal(t, tt.want, buf.String())
+			for _, unwanted := range tt.notContains {
+				assert.NotContains(t, buf.String(), unwanted)
+			}
+		})
+	}
 }

--- a/usefulerror/convert_grpc.go
+++ b/usefulerror/convert_grpc.go
@@ -98,6 +98,7 @@ func init() {
 			help := "Reduce request frequency or increase your quota."
 			code := ErrQuotaExceeded
 			humanError := "Quota exceeded"
+			referenceURL := ""
 
 			if errInfo, ok := getErrorInfoFromGrpcStatusDetails(st); ok {
 				switch errInfo.Reason {
@@ -108,9 +109,10 @@ func init() {
 						help = "Feature quota limit exceeded. Upgrade your plan for higher limit"
 						code = ErrRateLimitExceeded
 					case ErrAppQuotaReasonFeatureNotAvailable:
-						help = "Feature not available for your subscription tier."
+						help = "Enable this feature for your subscription or upgrade your plan, then retry."
 						code = ErrMissingEntitlements
 						humanError = "Feature unavailable"
+						referenceURL = "https://safedep.io/pricing"
 					}
 				}
 			}
@@ -119,6 +121,7 @@ func init() {
 				WithCode(code).
 				WithHumanError(humanError).
 				WithHelp(help).
+				WithReferenceURL(referenceURL).
 				WithAdditionalHelp(st.Message()).
 				Wrap(err), true
 		}
@@ -157,7 +160,8 @@ func init() {
 			return NewUsefulError().
 				WithCode(ErrInternalServerError).
 				WithHumanError("Internal server error").
-				WithHelp("An internal error occurred while processing the request.").
+				WithHelp("Retry the operation. If the error continues, contact SafeDep support.").
+				WithReferenceURL("https://docs.safedep.io/community").
 				WithAdditionalHelp(st.Message()).
 				Wrap(err), true
 		}

--- a/usefulerror/convert_grpc_test.go
+++ b/usefulerror/convert_grpc_test.go
@@ -18,6 +18,8 @@ func TestConvertGRPCToUsefulError(t *testing.T) {
 		input             error
 		expectedCode      string
 		expectedHuman     string
+		expectedHelp      string
+		expectedReference string
 		expectConversion  bool
 		additionalHelpSub string // substring expected to be present in AdditionalHelp (optional)
 	}{
@@ -89,6 +91,8 @@ func TestConvertGRPCToUsefulError(t *testing.T) {
 			input:             status.Errorf(codes.Internal, "panic"),
 			expectedCode:      ErrInternalServerError,
 			expectedHuman:     "Internal server error",
+			expectedHelp:      "Retry the operation. If the error continues, contact SafeDep support.",
+			expectedReference: "https://docs.safedep.io/community",
 			expectConversion:  true,
 			additionalHelpSub: "panic",
 		},
@@ -133,6 +137,12 @@ func TestConvertGRPCToUsefulError(t *testing.T) {
 			assert.NotNil(t, result)
 			assert.Equal(t, tt.expectedCode, result.Code(), "unexpected code")
 			assert.Equal(t, tt.expectedHuman, result.HumanError(), "unexpected human error")
+			if tt.expectedHelp != "" {
+				assert.Equal(t, tt.expectedHelp, result.Help(), "unexpected help")
+			}
+			if tt.expectedReference != "" {
+				assert.Equal(t, tt.expectedReference, result.ReferenceURL(), "unexpected reference URL")
+			}
 
 			if tt.additionalHelpSub != "" {
 				// AdditionalHelp may be the gRPC status message; ensure substring present.
@@ -195,7 +205,8 @@ func TestConvertGRPCToUsefulError_ResourceExhausted_WithDetails_FeatureNotAvaila
 	assert.NotNil(t, result)
 	assert.Equal(t, ErrMissingEntitlements, result.Code())
 	assert.Equal(t, "Feature unavailable", result.HumanError())
-	assert.Equal(t, "Feature not available for your subscription tier.", result.Help())
+	assert.Equal(t, "Enable this feature for your subscription or upgrade your plan, then retry.", result.Help())
+	assert.Equal(t, "https://safedep.io/pricing", result.ReferenceURL())
 	assert.Contains(t, result.AdditionalHelp(), "quota exceeded")
 }
 

--- a/usefulerror/status_consumer.go
+++ b/usefulerror/status_consumer.go
@@ -273,8 +273,9 @@ func init() {
 	})
 
 	RegisterReason(errorv1.ErrorReason_ERROR_REASON_PROJECT_NOT_SCANNABLE, ReasonPresentation{
-		Code:       ErrBadRequest,
-		HumanError: "Project not scannable",
-		Help:       "The project has no supported, usable source. Refresh the project source and retry.",
+		Code:         ErrBadRequest,
+		HumanError:   "Project not scannable",
+		Help:         "Grant the SafeDep GitHub App access to this repository, wait for project sync, then retry.",
+		ReferenceURL: "https://docs.safedep.io/governance/integrations/github",
 	})
 }

--- a/usefulerror/status_test.go
+++ b/usefulerror/status_test.go
@@ -188,7 +188,14 @@ func TestAsUsefulError_TypedReasonBeatsGenericCodeConverter(t *testing.T) {
 
 	useful, ok := AsUsefulError(err)
 	require.True(t, ok)
+	assert.Equal(t, ErrBadRequest, useful.Code())
 	assert.Equal(t, "Project not scannable", useful.HumanError())
+	assert.Equal(t,
+		"Grant the SafeDep GitHub App access to this repository, wait for project sync, then retry.",
+		useful.Help())
+	assert.Equal(t,
+		"https://docs.safedep.io/governance/integrations/github",
+		useful.ReferenceURL())
 }
 
 func TestAsUsefulError_UnregisteredReasonFallsBackToCode(t *testing.T) {


### PR DESCRIPTION
## Summary

- render `UsefulError` values with a code badge, human message, recovery steps, and optional reference link
- keep RPC diagnostics hidden in normal output and available in verbose output
- make project-source, missing-entitlement, and internal-server failures actionable

## Presentation

```text
[bad_request] Project not scannable
› Grant the SafeDep GitHub App access to this repository, wait for project sync, then retry.
› Learn more: https://docs.safedep.io/governance/integrations/github
```

```text
[missing_entitlements] Feature unavailable
› Enable this feature for your subscription or upgrade your plan, then retry.
› Learn more: https://safedep.io/pricing
```

## Verification

- `go test ./... -count=1`
- `go test -race ./... -count=1`
- `go vet ./tui/errors ./usefulerror`
- `./custom-gcl run --new-from-rev=origin/main ./...` (0 issues)
- staged `gitleaks protect`
- live SafeDep CLI project and package scan failures in a TTY

Full `go vet ./...` still reports the pre-existing duplicate JSON tag in generated `apiguard/tykgen` code. Neither generated file is changed by this PR.