### PR TITLE
fix(tui): improve error badge contrast

### DIFF
--- a/tui/style/style.go
+++ b/tui/style/style.go
@@ -70,6 +70,8 @@ func Badge(r theme.Role, text string) string {
 // Callers pass the semantic role (RoleCritical); we return the bg role (RoleBgCritical).
 func badgeBgFor(r theme.Role) theme.Role {
 	switch r {
+	case theme.RoleError:
+		return theme.RoleBgCritical
 	case theme.RoleCritical:
 		return theme.RoleBgCritical
 	case theme.RoleHigh:

--- a/tui/style/style_test.go
+++ b/tui/style/style_test.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/safedep/dry/tui/output"
+	"github.com/safedep/dry/tui/theme"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestStyleStripsColorInPlainMode(t *testing.T) {
@@ -37,4 +37,8 @@ func TestStyleRichEmitsAnsiUnlessNoColor(t *testing.T) {
 	got := Success("done")
 	// In Rich we expect the unicode icon at least.
 	assert.True(t, strings.Contains(got, "✓"))
+}
+
+func TestErrorBadgeUsesDarkBackground(t *testing.T) {
+	assert.Equal(t, theme.RoleBgCritical, badgeBgFor(theme.RoleError))
 }


### PR DESCRIPTION
## Summary

- render `RoleError` badges with the existing dark critical badge background
- keep the normal semantic error foreground unchanged
- add a regression test for the role mapping

## Root cause

`style.Badge` mapped severity roles to saturated badge backgrounds, but `RoleError` fell through to the semantic error foreground color. In dark terminals that color is pale red, so white badge text had insufficient contrast.

## User impact

Useful error codes keep the SafeDep CLI presentation while using a dark red background that remains readable with white text.

## Validation

- `go test ./... -count=1`
- `go test -race ./... -count=1`
- `go vet ./tui/style`
- `./custom-gcl run --new-from-rev=origin/main ./...` (0 issues)

Full `go vet ./...` remains blocked by the existing duplicate `certs` JSON tag in generated API Guard models.