### PR TITLE
feat(log): add ErrLevel to classify canonical event errors by level

### DIFF
--- a/docs/logger.md
+++ b/docs/logger.md
@@ -145,7 +145,7 @@ Canonical events work best when they capture *everything you'd want to know abou
 
 - **Always:** `request_id` (or equivalent correlation key), inputs that shape the response (path, method, key params), outcome (status, error class), and a duration.
 - **Often useful:** counts of expensive work (`db.queries`, `external_calls`, `cache.hits`/`cache.misses`), feature flags consumed, auth/tenant identity, downstream service latencies.
-- **Errors:** call `log.Err(ctx, err)` for known failure modes — it sets the canonical line's level to `error` and adds the `error` attribute. Don't `log.Errorf` separately; that emits a second line.
+- **Errors:** call `log.Err(ctx, err)` for known failure modes — it sets the canonical line's level to `error` and adds the `error` attribute. Don't `log.Errorf` separately; that emits a second line. For expected outcomes that should not read as faults (e.g. a gRPC `NotFound` on a lookup, or a `PermissionDenied` from an entitlement check), use `log.ErrLevel(ctx, err, level)` — it records the same `error` attribute but sets the level you pass instead of forcing `error`, so entry-point wrappers can classify by status code.
 - **Counters over repeated calls.** Use `log.Counter(ctx, "db.queries", 1)` in a loop, not `Set` (which overwrites and isn't atomic).
 
 ### What NOT to record

--- a/log/event.go
+++ b/log/event.go
@@ -207,6 +207,21 @@ func (e *Event) Err(err error) {
 	e.level = slog.LevelError
 }
 
+// ErrLevel records an error on the event and sets its level to the given
+// level. Unlike Err, it does not force the level to error, so an entry-point
+// wrapper can classify an expected error (e.g. a gRPC NotFound) below error.
+// Later Err or ErrLevel calls overwrite earlier ones. No-op if e is nil or
+// err is nil.
+func (e *Event) ErrLevel(err error, level slog.Level) {
+	if e == nil || err == nil {
+		return
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.attrs["error"] = err.Error()
+	e.level = level
+}
+
 // Set records an attribute on the event bound to ctx. No-op if no event.
 func Set(ctx context.Context, key string, value any) {
 	if ev := fromContext(ctx); ev != nil {
@@ -233,6 +248,16 @@ func Counter(ctx context.Context, key string, delta int64) {
 func Err(ctx context.Context, err error) {
 	if ev := fromContext(ctx); ev != nil {
 		ev.Err(err)
+	}
+}
+
+// ErrLevel records an error and sets the event level to the given level,
+// without the unconditional error promotion of Err. Use it at an entry
+// point that classifies expected errors (e.g. a gRPC NotFound) below error.
+// No-op if no event or if err is nil.
+func ErrLevel(ctx context.Context, err error, level slog.Level) {
+	if ev := fromContext(ctx); ev != nil {
+		ev.ErrLevel(err, level)
 	}
 }
 

--- a/log/event_test.go
+++ b/log/event_test.go
@@ -86,6 +86,36 @@ func TestEvent_Err_SetsErrorAttrAndLevel(t *testing.T) {
 	assert.Equal(t, slog.LevelError, ev.level)
 }
 
+func TestEvent_ErrLevel_SetsErrorAttrAndGivenLevel(t *testing.T) {
+	ctx, end := BeginEvent(context.Background(), "x")
+	defer end()
+
+	ErrLevel(ctx, errors.New("boom"), slog.LevelWarn)
+	ev := FromContext(ctx)
+
+	ev.mu.Lock()
+	defer ev.mu.Unlock()
+	assert.Equal(t, "boom", ev.attrs["error"])
+	assert.Equal(t, slog.LevelWarn, ev.level)
+}
+
+func TestEvent_ErrLevel_DoesNotForceError(t *testing.T) {
+	var buf bytes.Buffer
+	prev := globalLogger
+	defer func() { globalLogger = prev }()
+	globalLogger = newSlogTestLogger(t, &buf)
+
+	ctx, end := BeginEvent(context.Background(), "http.request")
+	ErrLevel(ctx, errors.New("resource not found"), slog.LevelInfo)
+	end()
+
+	var got map[string]any
+	err := json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &got)
+	assert.NoError(t, err)
+	assert.Equal(t, "INFO", got["level"])
+	assert.Equal(t, "resource not found", got["error"])
+}
+
 func TestEvent_Helpers_NoopWhenNoEvent(t *testing.T) {
 	ctx := context.Background()
 	// Must not panic.
@@ -93,6 +123,7 @@ func TestEvent_Helpers_NoopWhenNoEvent(t *testing.T) {
 	SetAttrs(ctx, map[string]any{"a": 1})
 	Counter(ctx, "c", 1)
 	Err(ctx, errors.New("x"))
+	ErrLevel(ctx, errors.New("x"), slog.LevelWarn)
 }
 
 func TestBeginEvent_EmitsOneRecordOnEnd(t *testing.T) {


### PR DESCRIPTION
## Problem

`log.Err` (and `(*Event).Err`) unconditionally promote the canonical log line to `error` level. Entry-point wrappers — the HTTP middleware (`adapters/http/middleware_event.go`), the ConnectRPC interceptor in control-tower, the async wrapper — call `log.Err(ctx, err)` for **every** returned error. As a result, expected outcomes such as a gRPC `NotFound` lookup miss or a `PermissionDenied` entitlement check are logged at `error` level. This inflates error-rate dashboards and alerting, and buries genuine faults.

The status code is available at these call sites, but there is currently no way to record an error while choosing the level — `Err` forces `error`.

## Change

Add `ErrLevel` (an `(*Event)` method and a package-level function) that records the same `error` attribute as `Err` but sets a caller-chosen level instead of forcing `error`:

```go
func (e *Event) ErrLevel(err error, level slog.Level)
func ErrLevel(ctx context.Context, err error, level slog.Level)
```

This lets an entry-point wrapper map the status code to an appropriate level (e.g. `NotFound` → info, `PermissionDenied` → warn, `Internal` → error) while keeping the error text queryable. `Err` is unchanged.

## Tests

- `TestEvent_ErrLevel_SetsErrorAttrAndGivenLevel` — records `error` attr and the given level.
- `TestEvent_ErrLevel_DoesNotForceError` — end-to-end emission asserts the line lands at `INFO`, not `ERROR`, with the `error` attribute present.
- Extended the no-op-without-event test to cover `ErrLevel`.

Also documented the helper in `docs/logger.md`.

Follow-up: control-tower's ConnectRPC interceptor will use this to classify `rpc.code` into levels, removing the dominant `NotFound`/`PermissionDenied` error-log noise from the community malysis pods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJZWsoXZSB9dbgnoPnvEUN)_