### PR TITLE
feat(tui): add meter package for static usage bars

### DIFF
--- a/tui/doc.go
+++ b/tui/doc.go
@@ -14,6 +14,6 @@
 //   - output.CurrentVerbosity() / output.SetVerbosity(...) — Silent/Normal/Verbose
 //
 // Components live in subpackages: banner, diff, table, spinner, progress,
-// prompt. Each is composable with the top-level helpers; none require touching
-// the theme API for the default SafeDep look.
+// meter, prompt. Each is composable with the top-level helpers; none require
+// touching the theme API for the default SafeDep look.
 package tui

--- a/tui/meter/meter.go
+++ b/tui/meter/meter.go
@@ -7,12 +7,14 @@
 // normal command output.
 //
 // Rich mode draws an aligned fill (█) over a track (░) per line; Plain and Agent
-// degrade to one "label: value/max (pct)" line each. A bar is monochrome unless
-// Warn is set, matching the house style where color signals only trouble.
+// degrade to one "label: value/max (pct)" line each. The bar fill is monochrome
+// unless Warn is set — color on the fill signals only trouble. Labels use the
+// muted role like the sibling panel and stat components.
 package meter
 
 import (
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
@@ -66,21 +68,23 @@ func renderRich(bars []Bar) string {
 	mutedC, _ := pal.ColorByRole(theme.RoleMuted)
 	labelStyle := lipgloss.NewStyle().Foreground(mutedC)
 
-	// Uniform label column so bars line up across rows.
+	// Uniform label column so bars line up across rows. Width is cell-aware
+	// (lipgloss), and lipgloss pads to that width the same way, so labels with
+	// double-width runes still align — fmt's code-point padding would not.
 	labelW := 0
 	for _, bar := range bars {
 		if w := lipgloss.Width(bar.Label); w > labelW {
 			labelW = w
 		}
 	}
+	labelStyle = labelStyle.Width(labelW)
 
 	var b strings.Builder
 	for i, bar := range bars {
 		if i > 0 {
 			b.WriteByte('\n')
 		}
-		label := labelStyle.Render(fmt.Sprintf("%-*s", labelW, bar.Label))
-		fmt.Fprintf(&b, "%s  %s  %s", label, renderTrack(bar), bar.ValueText)
+		fmt.Fprintf(&b, "%s  %s  %s", labelStyle.Render(bar.Label), renderTrack(bar), bar.ValueText)
 	}
 	return b.String()
 }
@@ -105,8 +109,9 @@ func warnRole(bar Bar) theme.Role {
 	return theme.RoleWarning
 }
 
-// fillCells is the number of filled cells for value out of max over width,
-// clamped to [0, width]. A non-positive max is an empty track.
+// fillCells is the number of filled cells for value out of max over width. A
+// non-positive max is an empty track; a full bar renders only at value >= max,
+// so a sub-max value is capped at width-1 even when rounding would reach width.
 func fillCells(value, max, width int64) int {
 	if max <= 0 || value <= 0 {
 		return 0
@@ -114,15 +119,28 @@ func fillCells(value, max, width int64) int {
 	if value >= max {
 		return int(width)
 	}
-	// Round to the nearest cell so a bar reaches full only at value == max.
-	cells := (value*width + max/2) / max
-	if cells > width {
-		cells = width
+
+	// Nearest-cell rounding, guarding value*width against int64 overflow for very
+	// large values by falling back to float division.
+	var cells int64
+	if value <= (math.MaxInt64-max/2)/width {
+		cells = (value*width + max/2) / max
+	} else {
+		cells = int64(float64(value) / float64(max) * float64(width))
+	}
+
+	// value < max here, so a full bar would be misleading.
+	if cells >= width {
+		cells = width - 1
+	}
+	if cells < 0 {
+		cells = 0
 	}
 	return int(cells)
 }
 
-// percent is value/max as an integer percentage, clamped to [0, 100].
+// percent is value/max as an integer percentage, clamped to [0, 100]. value*100
+// is guarded against int64 overflow the same way as fillCells.
 func percent(value, max int64) int {
 	if max <= 0 || value <= 0 {
 		return 0
@@ -130,5 +148,8 @@ func percent(value, max int64) int {
 	if value >= max {
 		return 100
 	}
-	return int((value * 100) / max)
+	if value <= math.MaxInt64/100 {
+		return int((value * 100) / max)
+	}
+	return int(float64(value) / float64(max) * 100)
 }

--- a/tui/meter/meter.go
+++ b/tui/meter/meter.go
@@ -1,0 +1,134 @@
+// tui/meter/meter.go
+//
+// Package meter renders static usage meters: a labelled fill/track bar with an
+// already-formatted value, for point-in-time "how much of X is used" output
+// (quota consumption, overage against a cap). Unlike tui/progress, which
+// animates in-flight work on stderr, a meter is a stable snapshot rendered into
+// normal command output.
+//
+// Rich mode draws an aligned fill (█) over a track (░) per line; Plain and Agent
+// degrade to one "label: value/max (pct)" line each. A bar is monochrome unless
+// Warn is set, matching the house style where color signals only trouble.
+package meter
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/safedep/dry/tui/output"
+	"github.com/safedep/dry/tui/theme"
+)
+
+// richBarWidth is the fixed cell width of the Rich fill/track bar.
+const richBarWidth = 26
+
+const (
+	fillRune  = "█"
+	trackRune = "░"
+)
+
+// Bar is one usage meter. Value out of Max drives the fill; ValueText is the
+// already-formatted reading shown after the bar (the caller owns formatting, so
+// the same primitive serves a unit bar and a money bar). Warn colors the fill
+// when the reading is at or near its ceiling; an unset Warn stays monochrome. A
+// non-positive Max renders an empty track.
+type Bar struct {
+	Label     string
+	Value     int64
+	Max       int64
+	ValueText string
+	Warn      bool
+}
+
+// Render lays the bars out for the active output mode.
+func Render(bars ...Bar) string {
+	if output.CurrentMode() != output.Rich {
+		return renderPlain(bars)
+	}
+	return renderRich(bars)
+}
+
+func renderPlain(bars []Bar) string {
+	var b strings.Builder
+	for i, bar := range bars {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		fmt.Fprintf(&b, "%s: %d/%d (%d%%)", bar.Label, bar.Value, bar.Max, percent(bar.Value, bar.Max))
+	}
+	return b.String()
+}
+
+func renderRich(bars []Bar) string {
+	pal := theme.Default().Palette()
+	mutedC, _ := pal.ColorByRole(theme.RoleMuted)
+	labelStyle := lipgloss.NewStyle().Foreground(mutedC)
+
+	// Uniform label column so bars line up across rows.
+	labelW := 0
+	for _, bar := range bars {
+		if w := lipgloss.Width(bar.Label); w > labelW {
+			labelW = w
+		}
+	}
+
+	var b strings.Builder
+	for i, bar := range bars {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		label := labelStyle.Render(fmt.Sprintf("%-*s", labelW, bar.Label))
+		fmt.Fprintf(&b, "%s  %s  %s", label, renderTrack(bar), bar.ValueText)
+	}
+	return b.String()
+}
+
+func renderTrack(bar Bar) string {
+	filled := fillCells(bar.Value, bar.Max, richBarWidth)
+	fill := strings.Repeat(fillRune, filled)
+	if bar.Warn && output.IsColorEnabled() {
+		if c, ok := theme.Default().Palette().ColorByRole(warnRole(bar)); ok {
+			fill = lipgloss.NewStyle().Foreground(c).Render(fill)
+		}
+	}
+	return fill + strings.Repeat(trackRune, richBarWidth-filled)
+}
+
+// warnRole escalates a warning bar to the error role once it is at or over its
+// ceiling, so a full bar reads as red and a near-full one as amber.
+func warnRole(bar Bar) theme.Role {
+	if bar.Max > 0 && bar.Value >= bar.Max {
+		return theme.RoleError
+	}
+	return theme.RoleWarning
+}
+
+// fillCells is the number of filled cells for value out of max over width,
+// clamped to [0, width]. A non-positive max is an empty track.
+func fillCells(value, max, width int64) int {
+	if max <= 0 || value <= 0 {
+		return 0
+	}
+	if value >= max {
+		return int(width)
+	}
+	// Round to the nearest cell so a bar reaches full only at value == max.
+	cells := (value*width + max/2) / max
+	if cells > width {
+		cells = width
+	}
+	return int(cells)
+}
+
+// percent is value/max as an integer percentage, clamped to [0, 100].
+func percent(value, max int64) int {
+	if max <= 0 || value <= 0 {
+		return 0
+	}
+	if value >= max {
+		return 100
+	}
+	return int((value * 100) / max)
+}

--- a/tui/meter/meter_test.go
+++ b/tui/meter/meter_test.go
@@ -1,0 +1,99 @@
+package meter
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/safedep/dry/tui/output"
+)
+
+func withMode(t *testing.T, m output.Mode) {
+	t.Helper()
+	prev := output.CurrentMode()
+	output.SetMode(m)
+	t.Cleanup(func() { output.SetMode(prev) })
+}
+
+func TestRenderPlainOneLinePerBar(t *testing.T) {
+	withMode(t, output.Plain)
+
+	got := Render(
+		Bar{Label: "Included", Value: 72, Max: 100, ValueText: "72 / 100 scans"},
+		Bar{Label: "Overage", Value: 0, Max: 100, ValueText: "$0.00 of $50.00 cap"},
+	)
+	assert.Equal(t, "Included: 72/100 (72%)\nOverage: 0/100 (0%)", got)
+}
+
+func TestRenderAgentDegradesLikePlain(t *testing.T) {
+	withMode(t, output.Agent)
+
+	got := Render(Bar{Label: "Included", Value: 50, Max: 100, ValueText: "50 / 100"})
+	assert.Equal(t, "Included: 50/100 (50%)", got)
+}
+
+func TestRenderRichDrawsFillAndTrackAndValueText(t *testing.T) {
+	withMode(t, output.Rich)
+
+	got := Render(Bar{Label: "Included", Value: 50, Max: 100, ValueText: "50 / 100 scans (50%)"})
+	assert.Contains(t, got, "Included")
+	assert.Contains(t, got, "50 / 100 scans (50%)")
+	// Half of a 26-cell bar rounds to 13 filled, 13 track.
+	assert.Equal(t, 13, strings.Count(got, fillRune))
+	assert.Equal(t, 13, strings.Count(got, trackRune))
+}
+
+func TestRenderRichFullAndEmpty(t *testing.T) {
+	withMode(t, output.Rich)
+
+	full := Render(Bar{Label: "Included", Value: 100, Max: 100, ValueText: "full"})
+	assert.Equal(t, richBarWidth, strings.Count(full, fillRune))
+	assert.Equal(t, 0, strings.Count(full, trackRune))
+
+	empty := Render(Bar{Label: "Overage", Value: 0, Max: 100, ValueText: "none"})
+	assert.Equal(t, 0, strings.Count(empty, fillRune))
+	assert.Equal(t, richBarWidth, strings.Count(empty, trackRune))
+}
+
+func TestRenderRichAlignsLabels(t *testing.T) {
+	withMode(t, output.Rich)
+
+	got := Render(
+		Bar{Label: "Included", Value: 1, Max: 10, ValueText: "a"},
+		Bar{Label: "Overage", Value: 1, Max: 10, ValueText: "b"},
+	)
+	lines := strings.Split(got, "\n")
+	// Labels are padded to a uniform width, so the bar column starts at the same
+	// byte offset on both rows.
+	assert.Equal(t, strings.Index(lines[0], fillRune), strings.Index(lines[1], fillRune))
+	assert.Equal(t, strings.LastIndex(lines[0], fillRune), strings.LastIndex(lines[1], fillRune))
+}
+
+func TestFillCells(t *testing.T) {
+	cases := []struct {
+		value, max int64
+		want       int
+	}{
+		{0, 100, 0},
+		{100, 100, 26},
+		{150, 100, 26}, // clamp over-max
+		{50, 100, 13},
+		{1, 100, 0},  // rounds down to empty
+		{2, 100, 1},  // rounds up to one cell
+		{10, 0, 0},   // non-positive max => empty
+		{-5, 100, 0}, // non-positive value => empty
+	}
+	for _, c := range cases {
+		assert.Equalf(t, c.want, fillCells(c.value, c.max, richBarWidth),
+			"fillCells(%d,%d)", c.value, c.max)
+	}
+}
+
+func TestPercent(t *testing.T) {
+	assert.Equal(t, 0, percent(0, 100))
+	assert.Equal(t, 72, percent(72, 100))
+	assert.Equal(t, 100, percent(100, 100))
+	assert.Equal(t, 100, percent(150, 100)) // clamp
+	assert.Equal(t, 0, percent(10, 0))      // non-positive max
+}

--- a/tui/meter/meter_test.go
+++ b/tui/meter/meter_test.go
@@ -1,6 +1,7 @@
 package meter
 
 import (
+	"math"
 	"strings"
 	"testing"
 
@@ -79,10 +80,12 @@ func TestFillCells(t *testing.T) {
 		{100, 100, 26},
 		{150, 100, 26}, // clamp over-max
 		{50, 100, 13},
-		{1, 100, 0},  // rounds down to empty
-		{2, 100, 1},  // rounds up to one cell
-		{10, 0, 0},   // non-positive max => empty
-		{-5, 100, 0}, // non-positive value => empty
+		{1, 100, 0},                            // rounds down to empty
+		{2, 100, 1},                            // rounds up to one cell
+		{99, 100, 25},                          // sub-max never renders as full (would round to 26)
+		{10, 0, 0},                             // non-positive max => empty
+		{-5, 100, 0},                           // non-positive value => empty
+		{math.MaxInt64 - 1, math.MaxInt64, 25}, // huge sub-max value: no overflow, capped below full
 	}
 	for _, c := range cases {
 		assert.Equalf(t, c.want, fillCells(c.value, c.max, richBarWidth),
@@ -96,4 +99,8 @@ func TestPercent(t *testing.T) {
 	assert.Equal(t, 100, percent(100, 100))
 	assert.Equal(t, 100, percent(150, 100)) // clamp
 	assert.Equal(t, 0, percent(10, 0))      // non-positive max
+	// Huge sub-max value must not overflow value*100 into a wrong/negative result.
+	huge := percent(math.MaxInt64-1, math.MaxInt64)
+	assert.GreaterOrEqual(t, huge, 99)
+	assert.LessOrEqual(t, huge, 100)
 }


### PR DESCRIPTION
## Summary

Adds `tui/meter`, a mode-aware **static usage meter** — a labelled fill/track bar with an already-formatted value, for point-in-time "how much of X is used" output (quota consumption, overage against a cap).

It fills a real gap in `tui`: `tui/progress` animates in-flight work on stderr (wrong primitive for a snapshot), and `tui/stat` shows metric cards with no bar. This is **PR-C** of the metered-usage-bars effort; the CLI (`safedep subscription ondemand status`) will use it to render usage/overage bars from the new `MeteredFeatureUsage` API. Independent of the api/control-tower work — no dependency on them.

## API

```go
type Bar struct {
    Label     string
    Value     int64
    Max       int64
    ValueText string // caller-formatted, e.g. "72 / 100 scans (72%)" or "$21.50 of $50.00 cap"
    Warn      bool
}

func Render(bars ...Bar) string
```

## Behaviour

- **Rich:** an aligned fill (`█`) over track (`░`) per line, labels padded into a uniform column, then `ValueText`.
- **Plain / Agent:** degrade to `label: value/max (pct)`.
- **Monochrome by default** — color is gated on `output.IsColorEnabled()` and applied only when `Warn`, matching the house style where color signals only trouble. At/over the ceiling escalates to `RoleError`, near it to `RoleWarning`.
- `ValueText` is caller-owned, so the same primitive serves a unit bar and a money bar without embedding domain formatting in `dry`.

Follows the `tui/stat` / `tui/panel` structure (mode switch, `theme.Default().Palette()`, lipgloss).

## Testing

`go test ./tui/meter/` — Plain/Agent one-line format, Rich fill/track counts (half / full / empty), label alignment across rows, and table tests for the `fillCells` rounding + clamp and `percent` math. `go build ./...`, `go vet`, `gofmt` clean. Added `meter` to the `tui/doc.go` component list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mb1RG59FZK7YDWv1FBybcf)_