### PR TITLE
feat(inbox): bounded-retry dead-letter policy for poison records

### DIFF
--- a/events/inbox/deadletter.go
+++ b/events/inbox/deadletter.go
@@ -38,9 +38,12 @@ type DeadLetter struct {
 
 func (DeadLetter) TableName() string { return "event_inbox_dead_letter" }
 
-// DeadLetterRecord is the input to DeadLetterQueue.Store. Payload is required and
-// is the source of truth; EventID and Feed are optional context populated only
-// when the caller has decoded the envelope.
+// DeadLetterRecord is the input to DeadLetterQueue.Store. Payload is the raw
+// record and the source of truth; EventID and Feed are optional context populated
+// only when the caller has decoded the envelope. An empty payload is accepted on
+// purpose: a zero-length poison record (e.g. one whose envelope won't decode)
+// must still be dead-letterable, or the feed it blocks could never advance — the
+// exact stall this package exists to prevent.
 type DeadLetterRecord struct {
 	Payload  []byte
 	Error    string
@@ -82,11 +85,9 @@ func NewGormDeadLetter(adapter db.SqlDataAdapter, consumerName string) (DeadLett
 }
 
 func (q *gormDeadLetter) Store(ctx context.Context, rec DeadLetterRecord) error {
-	if len(rec.Payload) == 0 {
-		// Payload is the record we must not lose and the dedup key; an empty one is
-		// a caller bug, not a record to persist under a constant "empty" hash.
-		return fmt.Errorf("inbox: dead-letter store: payload is required")
-	}
+	// An empty payload is stored, not rejected: SHA-256 of empty is still a stable
+	// dedup key, and refusing it would make the retry policy loop forever on a
+	// zero-length poison record (Store error -> Retry) — reintroducing the stall.
 	row := DeadLetter{
 		ConsumerName: q.consumerName,
 		PayloadHash:  payloadFingerprint(rec.Payload),

--- a/events/inbox/deadletter.go
+++ b/events/inbox/deadletter.go
@@ -1,0 +1,112 @@
+package inbox
+
+import (
+	"context"
+	"fmt"
+	"hash/fnv"
+	"strconv"
+	"time"
+
+	"github.com/safedep/dry/db"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// DeadLetter is one record a consumer could not process and has given up
+// retrying. It preserves the raw Payload so the event is never lost — an
+// operator can inspect it and replay it out of band. Same identity shape as
+// Cursor / ProcessedEvent: surrogate PK plus a unique index on the natural key.
+//
+// The natural key is (consumer_name, payload_hash), not (consumer_name,
+// event_id): a decode failure has no event_id, and a redelivered poison record
+// carries identical bytes, so hashing the payload dedups redeliveries whether or
+// not the envelope could be read. EventID / Feed are best-effort context for
+// triage queries — empty when the generic retry policy dead-letters, since it
+// does not decode the payload.
+type DeadLetter struct {
+	ID           uint64    `gorm:"primaryKey;autoIncrement"`
+	ConsumerName string    `gorm:"column:consumer_name;uniqueIndex:idx_event_inbox_dead_letter_unique,priority:1"`
+	PayloadHash  string    `gorm:"column:payload_hash;uniqueIndex:idx_event_inbox_dead_letter_unique,priority:2"`
+	Feed         string    `gorm:"column:feed"`
+	EventID      string    `gorm:"column:event_id"`
+	Payload      []byte    `gorm:"column:payload"`
+	Error        string    `gorm:"column:error"`
+	Attempts     int       `gorm:"column:attempts"`
+	FailedAt     time.Time `gorm:"column:failed_at;index:idx_event_inbox_dead_letter_failed_at"`
+}
+
+func (DeadLetter) TableName() string { return "event_inbox_dead_letter" }
+
+// DeadLetterRecord is the input to DeadLetterQueue.Store. Payload is required and
+// is the source of truth; EventID and Feed are optional context populated only
+// when the caller has decoded the envelope.
+type DeadLetterRecord struct {
+	Payload  []byte
+	Error    string
+	Attempts int
+	EventID  string
+	Feed     string
+}
+
+// DeadLetterQueue persists records a consumer has given up on. It is the sink an
+// error policy skips a poison record into (see NewRetryPolicy) so the feed can
+// advance without dropping data.
+type DeadLetterQueue interface {
+	Store(ctx context.Context, rec DeadLetterRecord) error
+}
+
+type gormDeadLetter struct {
+	db           *gorm.DB
+	consumerName string
+}
+
+var _ DeadLetterQueue = &gormDeadLetter{}
+
+// NewGormDeadLetter builds a consumer-scoped DeadLetterQueue over the consumer's
+// SQL adapter. The consumer name is bound here so Store stays keyless, mirroring
+// NewGormDedup.
+func NewGormDeadLetter(adapter db.SqlDataAdapter, consumerName string) (DeadLetterQueue, error) {
+	if adapter == nil {
+		return nil, fmt.Errorf("inbox: dead-letter queue: adapter is required")
+	}
+	if consumerName == "" {
+		// An empty name would silently share one dead-letter set across consumers.
+		return nil, fmt.Errorf("inbox: dead-letter queue: consumer name is required")
+	}
+	gdb, err := adapter.GetDB()
+	if err != nil {
+		return nil, fmt.Errorf("inbox: dead-letter queue: %w", err)
+	}
+	return &gormDeadLetter{db: gdb, consumerName: consumerName}, nil
+}
+
+func (q *gormDeadLetter) Store(ctx context.Context, rec DeadLetterRecord) error {
+	row := DeadLetter{
+		ConsumerName: q.consumerName,
+		PayloadHash:  payloadFingerprint(rec.Payload),
+		Feed:         rec.Feed,
+		EventID:      rec.EventID,
+		Payload:      rec.Payload,
+		Error:        rec.Error,
+		Attempts:     rec.Attempts,
+		FailedAt:     time.Now(),
+	}
+	// Idempotent: a redelivered poison record hashes to the same key, so a repeat
+	// dead-letter is a no-op rather than a duplicate row or an error.
+	err := q.db.WithContext(ctx).
+		Clauses(clause.OnConflict{DoNothing: true}).
+		Create(&row).Error
+	if err != nil {
+		return fmt.Errorf("inbox: dead-letter store: %w", err)
+	}
+	return nil
+}
+
+// payloadFingerprint is a stable content key over a raw record. Redeliveries of
+// the same bytes fingerprint identically, which backs both the retry policy's
+// consecutive-failure counter and the dead-letter table's dedup key.
+func payloadFingerprint(payload []byte) string {
+	h := fnv.New64a()
+	_, _ = h.Write(payload)
+	return strconv.FormatUint(h.Sum64(), 16)
+}

--- a/events/inbox/deadletter.go
+++ b/events/inbox/deadletter.go
@@ -2,9 +2,10 @@ package inbox
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
-	"hash/fnv"
-	"strconv"
+	"strings"
 	"time"
 
 	"github.com/safedep/dry/db"
@@ -81,15 +82,24 @@ func NewGormDeadLetter(adapter db.SqlDataAdapter, consumerName string) (DeadLett
 }
 
 func (q *gormDeadLetter) Store(ctx context.Context, rec DeadLetterRecord) error {
+	if len(rec.Payload) == 0 {
+		// Payload is the record we must not lose and the dedup key; an empty one is
+		// a caller bug, not a record to persist under a constant "empty" hash.
+		return fmt.Errorf("inbox: dead-letter store: payload is required")
+	}
 	row := DeadLetter{
 		ConsumerName: q.consumerName,
 		PayloadHash:  payloadFingerprint(rec.Payload),
-		Feed:         rec.Feed,
-		EventID:      rec.EventID,
+		Feed:         sanitizeForText(rec.Feed),
+		EventID:      sanitizeForText(rec.EventID),
 		Payload:      rec.Payload,
-		Error:        rec.Error,
-		Attempts:     rec.Attempts,
-		FailedAt:     time.Now(),
+		// The error string can itself carry a NUL or invalid UTF-8 (the very poison
+		// that triggered the failure), which Postgres would reject — sinking the
+		// dead-letter insert and defeating the whole point. Sanitize the text
+		// columns; the raw bytes stay untouched in Payload.
+		Error:    sanitizeForText(rec.Error),
+		Attempts: rec.Attempts,
+		FailedAt: time.Now(),
 	}
 	// Idempotent: a redelivered poison record hashes to the same key, so a repeat
 	// dead-letter is a no-op rather than a duplicate row or an error.
@@ -104,9 +114,20 @@ func (q *gormDeadLetter) Store(ctx context.Context, rec DeadLetterRecord) error 
 
 // payloadFingerprint is a stable content key over a raw record. Redeliveries of
 // the same bytes fingerprint identically, which backs both the retry policy's
-// consecutive-failure counter and the dead-letter table's dedup key.
+// consecutive-failure counter and the dead-letter table's dedup key. SHA-256 (not
+// a 64-bit hash) so a collision can't make a distinct poison record dedup away as
+// "already stored" and get skipped — that would be silent data loss.
 func payloadFingerprint(payload []byte) string {
-	h := fnv.New64a()
-	_, _ = h.Write(payload)
-	return strconv.FormatUint(h.Sum64(), 16)
+	sum := sha256.Sum256(payload)
+	return hex.EncodeToString(sum[:])
+}
+
+// sanitizeForText makes a diagnostic string safe for a Postgres text column,
+// which rejects NUL (0x00) and invalid UTF-8. Only the human-readable columns are
+// coerced; the raw record is preserved verbatim in the bytea payload column.
+func sanitizeForText(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToValidUTF8(strings.ReplaceAll(s, "\x00", ""), "")
 }

--- a/events/inbox/deadletter_test.go
+++ b/events/inbox/deadletter_test.go
@@ -1,0 +1,92 @@
+package inbox_test
+
+import (
+	"testing"
+
+	"github.com/safedep/dry/events/inbox"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewGormDeadLetter_Validation(t *testing.T) {
+	_, err := inbox.NewGormDeadLetter(nil, "c")
+	require.Error(t, err, "nil adapter is rejected")
+
+	_, err = inbox.NewGormDeadLetter(newTestAdapter(t), "")
+	require.Error(t, err, "empty consumer name is rejected")
+}
+
+func TestGormDeadLetter_StorePersistsRecord(t *testing.T) {
+	adapter := newTestAdapter(t)
+	q, err := inbox.NewGormDeadLetter(adapter, "consumer-a")
+	require.NoError(t, err)
+
+	require.NoError(t, q.Store(t.Context(), inbox.DeadLetterRecord{
+		Payload:  []byte("poison-bytes"),
+		Error:    "boom",
+		Attempts: 4,
+		EventID:  "evt-1",
+		Feed:     "feed.v1.X",
+	}))
+
+	gdb, err := adapter.GetDB()
+	require.NoError(t, err)
+
+	var rows []inbox.DeadLetter
+	require.NoError(t, gdb.Find(&rows).Error)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "consumer-a", rows[0].ConsumerName)
+	assert.Equal(t, []byte("poison-bytes"), rows[0].Payload)
+	assert.Equal(t, "boom", rows[0].Error)
+	assert.Equal(t, 4, rows[0].Attempts)
+	assert.Equal(t, "evt-1", rows[0].EventID)
+	assert.Equal(t, "feed.v1.X", rows[0].Feed)
+	assert.NotEmpty(t, rows[0].PayloadHash)
+	assert.False(t, rows[0].FailedAt.IsZero())
+}
+
+func TestGormDeadLetter_StoreIsIdempotentOnPayload(t *testing.T) {
+	adapter := newTestAdapter(t)
+	q, err := inbox.NewGormDeadLetter(adapter, "consumer-a")
+	require.NoError(t, err)
+
+	// Same bytes redelivered and dead-lettered twice → one row, no error.
+	rec := inbox.DeadLetterRecord{Payload: []byte("same"), Error: "e", Attempts: 4}
+	require.NoError(t, q.Store(t.Context(), rec))
+	require.NoError(t, q.Store(t.Context(), rec))
+
+	gdb, err := adapter.GetDB()
+	require.NoError(t, err)
+	var count int64
+	require.NoError(t, gdb.Model(&inbox.DeadLetter{}).Count(&count).Error)
+	assert.Equal(t, int64(1), count)
+}
+
+func TestGormDeadLetter_DistinctPayloadsAndConsumersCoexist(t *testing.T) {
+	adapter := newTestAdapter(t)
+	qa, err := inbox.NewGormDeadLetter(adapter, "consumer-a")
+	require.NoError(t, err)
+	qb, err := inbox.NewGormDeadLetter(adapter, "consumer-b")
+	require.NoError(t, err)
+
+	require.NoError(t, qa.Store(t.Context(), inbox.DeadLetterRecord{Payload: []byte("p1")}))
+	require.NoError(t, qa.Store(t.Context(), inbox.DeadLetterRecord{Payload: []byte("p2")}))
+	// Same payload as consumer-a's p1, but a different consumer → separate row.
+	require.NoError(t, qb.Store(t.Context(), inbox.DeadLetterRecord{Payload: []byte("p1")}))
+
+	gdb, err := adapter.GetDB()
+	require.NoError(t, err)
+	var count int64
+	require.NoError(t, gdb.Model(&inbox.DeadLetter{}).Count(&count).Error)
+	assert.Equal(t, int64(3), count)
+}
+
+// Migrate is idempotent — a second call over the same DB must not error.
+func TestMigrate_Idempotent(t *testing.T) {
+	adapter := newTestAdapter(t) // already migrates once
+	require.NoError(t, inbox.Migrate(adapter))
+
+	gdb, err := adapter.GetDB()
+	require.NoError(t, err)
+	assert.True(t, gdb.Migrator().HasTable(&inbox.DeadLetter{}))
+}

--- a/events/inbox/deadletter_test.go
+++ b/events/inbox/deadletter_test.go
@@ -2,6 +2,7 @@ package inbox_test
 
 import (
 	"testing"
+	"unicode/utf8"
 
 	"github.com/safedep/dry/events/inbox"
 	"github.com/stretchr/testify/assert"
@@ -79,6 +80,39 @@ func TestGormDeadLetter_DistinctPayloadsAndConsumersCoexist(t *testing.T) {
 	var count int64
 	require.NoError(t, gdb.Model(&inbox.DeadLetter{}).Count(&count).Error)
 	assert.Equal(t, int64(3), count)
+}
+
+func TestGormDeadLetter_RejectsEmptyPayload(t *testing.T) {
+	q, err := inbox.NewGormDeadLetter(newTestAdapter(t), "consumer-a")
+	require.NoError(t, err)
+
+	require.Error(t, q.Store(t.Context(), inbox.DeadLetterRecord{Payload: nil, Error: "e"}),
+		"payload is the record and the dedup key; nil must be rejected, not stored under a constant hash")
+}
+
+func TestGormDeadLetter_SanitizesTextColumns(t *testing.T) {
+	adapter := newTestAdapter(t)
+	q, err := inbox.NewGormDeadLetter(adapter, "consumer-a")
+	require.NoError(t, err)
+
+	// The error string carries the very poison that failed the handler: a NUL and
+	// an invalid UTF-8 byte. Postgres would reject those in a text column, sinking
+	// the dead-letter insert — so they must be stripped before persistence.
+	require.NoError(t, q.Store(t.Context(), inbox.DeadLetterRecord{
+		Payload: []byte("raw\x00bytes"),
+		Error:   "bad\x00utf\xff8",
+	}))
+
+	gdb, err := adapter.GetDB()
+	require.NoError(t, err)
+	var row inbox.DeadLetter
+	require.NoError(t, gdb.First(&row).Error)
+
+	assert.NotContains(t, row.Error, "\x00")
+	assert.True(t, utf8.ValidString(row.Error), "error column must be valid UTF-8")
+	assert.Equal(t, "badutf8", row.Error)
+	// Payload is bytea: stored verbatim, NUL and all — the lossless replay source.
+	assert.Equal(t, []byte("raw\x00bytes"), row.Payload)
 }
 
 // Migrate is idempotent — a second call over the same DB must not error.

--- a/events/inbox/deadletter_test.go
+++ b/events/inbox/deadletter_test.go
@@ -82,12 +82,23 @@ func TestGormDeadLetter_DistinctPayloadsAndConsumersCoexist(t *testing.T) {
 	assert.Equal(t, int64(3), count)
 }
 
-func TestGormDeadLetter_RejectsEmptyPayload(t *testing.T) {
-	q, err := inbox.NewGormDeadLetter(newTestAdapter(t), "consumer-a")
+func TestGormDeadLetter_StoresEmptyPayload(t *testing.T) {
+	adapter := newTestAdapter(t)
+	q, err := inbox.NewGormDeadLetter(adapter, "consumer-a")
 	require.NoError(t, err)
 
-	require.Error(t, q.Store(t.Context(), inbox.DeadLetterRecord{Payload: nil, Error: "e"}),
-		"payload is the record and the dedup key; nil must be rejected, not stored under a constant hash")
+	// A zero-length poison record must be dead-letterable: rejecting it would make
+	// the retry policy loop forever (Store error -> Retry), the exact stall this
+	// package prevents.
+	require.NoError(t, q.Store(t.Context(), inbox.DeadLetterRecord{Payload: nil, Error: "no envelope"}))
+
+	gdb, err := adapter.GetDB()
+	require.NoError(t, err)
+	var rows []inbox.DeadLetter
+	require.NoError(t, gdb.Find(&rows).Error)
+	require.Len(t, rows, 1)
+	assert.NotEmpty(t, rows[0].PayloadHash, "empty payload still gets a stable dedup key")
+	assert.Equal(t, "no envelope", rows[0].Error)
 }
 
 func TestGormDeadLetter_SanitizesTextColumns(t *testing.T) {

--- a/events/inbox/migrate.go
+++ b/events/inbox/migrate.go
@@ -4,13 +4,13 @@ import "github.com/safedep/dry/db"
 
 // Migrate creates/updates the inbox tables via the consumer's adapter. The tables
 // live in the consumer's database; dry owns only the models. Run it from the
-// consumer's migration pipeline. The processed-event table is only used when
-// WithDedup is enabled, but is migrated unconditionally so enabling dedup later
-// needs no schema change.
+// consumer's migration pipeline. The processed-event and dead-letter tables are
+// only used when WithDedup / a dead-letter error policy are enabled, but are
+// migrated unconditionally so enabling either later needs no schema change.
 func Migrate(adapter db.SqlDataAdapter) error {
 	gdb, err := adapter.GetDB()
 	if err != nil {
 		return err
 	}
-	return gdb.AutoMigrate(&Cursor{}, &ProcessedEvent{})
+	return gdb.AutoMigrate(&Cursor{}, &ProcessedEvent{}, &DeadLetter{})
 }

--- a/events/inbox/retry.go
+++ b/events/inbox/retry.go
@@ -2,12 +2,14 @@ package inbox
 
 import (
 	"context"
+	"errors"
 
 	"github.com/safedep/dry/log"
 )
 
-// DefaultMaxAttempts is the retry budget NewRetryPolicy uses when the caller does
-// not set one: a record is retried this many times before it is dead-lettered.
+// DefaultMaxAttempts is the delivery budget NewRetryPolicy uses when the caller
+// does not set one: the total number of failed deliveries a record gets — the
+// last of which dead-letters it — so it is retried DefaultMaxAttempts-1 times.
 const DefaultMaxAttempts = 4
 
 type retryConfig struct {
@@ -18,9 +20,9 @@ type retryConfig struct {
 // RetryOption configures NewRetryPolicy.
 type RetryOption func(*retryConfig)
 
-// WithMaxAttempts sets the retry budget before a record is dead-lettered. Values
-// below 1 are ignored (the default stands), so a record is always tried at least
-// once.
+// WithMaxAttempts sets the total number of failed deliveries a record gets before
+// it is dead-lettered (so retries = n-1). Values below 1 are ignored (the default
+// stands), so a record is always tried at least once.
 func WithMaxAttempts(n int) RetryOption {
 	return func(c *retryConfig) {
 		if n >= 1 {
@@ -33,7 +35,9 @@ func WithMaxAttempts(n int) RetryOption {
 // whether an error is permanent (a poison record that will never succeed). When
 // it returns true the record is dead-lettered immediately, skipping the retry
 // budget. This is the seam for transport- or storage-specific knowledge (e.g. a
-// Postgres data-exception SQLSTATE) so the generic policy stays free of it.
+// Postgres data-exception SQLSTATE) so the generic policy stays free of it. The
+// predicate receives the unwrapped root cause (Consume wraps handler/decode
+// errors), so both typed (errors.As) and message-based checks work.
 func WithPermanentClassifier(f func(error) bool) RetryOption {
 	return func(c *retryConfig) { c.permanent = f }
 }
@@ -73,7 +77,7 @@ func NewRetryPolicy(dlq DeadLetterQueue, opts ...RetryOption) ErrorHandler {
 			attempts = 1
 		}
 
-		permanent := cfg.permanent != nil && cfg.permanent(cause)
+		permanent := cfg.permanent != nil && cfg.permanent(rootCause(cause))
 		if !permanent && attempts < cfg.maxAttempts {
 			return Retry
 		}
@@ -94,7 +98,22 @@ func NewRetryPolicy(dlq DeadLetterQueue, opts ...RetryOption) ErrorHandler {
 			return Retry
 		}
 
-		log.Warnf("inbox: dead-lettered record after %d attempt(s): %v", attempts, cause)
+		// Debug, not Warn: dispose already logs a Warn when it acts on Skip, so a
+		// Warn here would double-log every dead-lettered record.
+		log.Debugf("inbox: dead-lettered record after %d attempt(s): %v", attempts, cause)
 		return Skip
+	}
+}
+
+// rootCause unwraps err to the deepest error in its chain, so a classifier sees
+// the underlying transport/storage error rather than Consume's "handler: %w" /
+// "decode: %w" wrapper.
+func rootCause(err error) error {
+	for {
+		u := errors.Unwrap(err)
+		if u == nil {
+			return err
+		}
+		err = u
 	}
 }

--- a/events/inbox/retry.go
+++ b/events/inbox/retry.go
@@ -57,6 +57,11 @@ func WithPermanentClassifier(f func(error) bool) RetryOption {
 // budget is exhausted. If dlq is nil, or the dead-letter Store fails, the record
 // is retried instead of skipped — the feed never drops data it could not first
 // persist.
+//
+// The returned ErrorHandler is stateful (it closes over the last record's
+// fingerprint and attempt count) and is NOT safe for concurrent use: create one
+// per Consume call. Consume invokes its handler single-threaded, so a per-feed
+// policy needs no locking; sharing one across feeds would race and mix budgets.
 func NewRetryPolicy(dlq DeadLetterQueue, opts ...RetryOption) ErrorHandler {
 	cfg := retryConfig{maxAttempts: DefaultMaxAttempts}
 	for _, o := range opts {
@@ -77,7 +82,7 @@ func NewRetryPolicy(dlq DeadLetterQueue, opts ...RetryOption) ErrorHandler {
 			attempts = 1
 		}
 
-		permanent := cfg.permanent != nil && cfg.permanent(rootCause(cause))
+		permanent := cause != nil && cfg.permanent != nil && cfg.permanent(rootCause(cause))
 		if !permanent && attempts < cfg.maxAttempts {
 			return Retry
 		}
@@ -91,7 +96,7 @@ func NewRetryPolicy(dlq DeadLetterQueue, opts ...RetryOption) ErrorHandler {
 
 		if err := dlq.Store(ctx, DeadLetterRecord{
 			Payload:  d.Payload,
-			Error:    cause.Error(),
+			Error:    errString(cause),
 			Attempts: attempts,
 		}); err != nil {
 			log.Warnf("inbox: dead-letter store failed (record will be retried): %v", err)
@@ -103,6 +108,15 @@ func NewRetryPolicy(dlq DeadLetterQueue, opts ...RetryOption) ErrorHandler {
 		log.Debugf("inbox: dead-lettered record after %d attempt(s): %v", attempts, cause)
 		return Skip
 	}
+}
+
+// errString is cause.Error() guarded against a nil error. Consume always passes a
+// non-nil cause today; this keeps the exported policy panic-safe against misuse.
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
 }
 
 // rootCause unwraps err to the deepest error in its chain, so a classifier sees

--- a/events/inbox/retry.go
+++ b/events/inbox/retry.go
@@ -1,0 +1,100 @@
+package inbox
+
+import (
+	"context"
+
+	"github.com/safedep/dry/log"
+)
+
+// DefaultMaxAttempts is the retry budget NewRetryPolicy uses when the caller does
+// not set one: a record is retried this many times before it is dead-lettered.
+const DefaultMaxAttempts = 4
+
+type retryConfig struct {
+	maxAttempts int
+	permanent   func(error) bool
+}
+
+// RetryOption configures NewRetryPolicy.
+type RetryOption func(*retryConfig)
+
+// WithMaxAttempts sets the retry budget before a record is dead-lettered. Values
+// below 1 are ignored (the default stands), so a record is always tried at least
+// once.
+func WithMaxAttempts(n int) RetryOption {
+	return func(c *retryConfig) {
+		if n >= 1 {
+			c.maxAttempts = n
+		}
+	}
+}
+
+// WithPermanentClassifier supplies a consumer-owned predicate that reports
+// whether an error is permanent (a poison record that will never succeed). When
+// it returns true the record is dead-lettered immediately, skipping the retry
+// budget. This is the seam for transport- or storage-specific knowledge (e.g. a
+// Postgres data-exception SQLSTATE) so the generic policy stays free of it.
+func WithPermanentClassifier(f func(error) bool) RetryOption {
+	return func(c *retryConfig) { c.permanent = f }
+}
+
+// NewRetryPolicy returns an ErrorHandler that retries a failing record a bounded
+// number of times and then dead-letters it, so one poison record can never
+// head-of-line-block the feed forever (the default Retry policy's failure mode).
+//
+// A record's identity is a fingerprint of its raw bytes. Consume is single-
+// threaded and a Nack redelivers the same record as the very next Receive, so a
+// consecutive-failure counter over the last-seen fingerprint is sufficient — no
+// per-record persistence. The counter resets when a different record arrives or
+// the process restarts; a restart therefore re-grants the budget, which still
+// bounds retries per run and eventually dead-letters a durable poison record.
+//
+// A record is dead-lettered when the classifier marks it permanent, or the retry
+// budget is exhausted. If dlq is nil, or the dead-letter Store fails, the record
+// is retried instead of skipped — the feed never drops data it could not first
+// persist.
+func NewRetryPolicy(dlq DeadLetterQueue, opts ...RetryOption) ErrorHandler {
+	cfg := retryConfig{maxAttempts: DefaultMaxAttempts}
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	var (
+		lastKey  string
+		attempts int
+	)
+
+	return func(ctx context.Context, d *Delivery, cause error) Disposition {
+		key := payloadFingerprint(d.Payload)
+		if key == lastKey {
+			attempts++
+		} else {
+			lastKey = key
+			attempts = 1
+		}
+
+		permanent := cfg.permanent != nil && cfg.permanent(cause)
+		if !permanent && attempts < cfg.maxAttempts {
+			return Retry
+		}
+
+		if dlq == nil {
+			// No sink wired: preserve the record by retrying rather than dropping
+			// it. This keeps the zero-DLQ configuration as safe as the legacy
+			// infinite-Retry default.
+			return Retry
+		}
+
+		if err := dlq.Store(ctx, DeadLetterRecord{
+			Payload:  d.Payload,
+			Error:    cause.Error(),
+			Attempts: attempts,
+		}); err != nil {
+			log.Warnf("inbox: dead-letter store failed (record will be retried): %v", err)
+			return Retry
+		}
+
+		log.Warnf("inbox: dead-lettered record after %d attempt(s): %v", attempts, cause)
+		return Skip
+	}
+}

--- a/events/inbox/retry_test.go
+++ b/events/inbox/retry_test.go
@@ -1,0 +1,145 @@
+package inbox_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	commonv1 "buf.build/gen/go/safedep/api/protocolbuffers/go/safedep/events/common/v1"
+	pkgregv1 "buf.build/gen/go/safedep/api/protocolbuffers/go/safedep/events/private/packageregistry/v1"
+	"github.com/safedep/dry/events/inbox"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeDLQ struct {
+	stored  []inbox.DeadLetterRecord
+	failErr error
+}
+
+func (f *fakeDLQ) Store(_ context.Context, rec inbox.DeadLetterRecord) error {
+	if f.failErr != nil {
+		return f.failErr
+	}
+	f.stored = append(f.stored, rec)
+	return nil
+}
+
+func delivery(payload string) *inbox.Delivery {
+	return &inbox.Delivery{Payload: []byte(payload)}
+}
+
+func TestRetryPolicy_RetriesUntilBudgetThenDeadLetters(t *testing.T) {
+	dlq := &fakeDLQ{}
+	policy := inbox.NewRetryPolicy(dlq, inbox.WithMaxAttempts(3))
+	cause := errors.New("boom")
+	d := delivery("poison")
+
+	// Same record fails repeatedly. First two attempts retry; the third exhausts
+	// the budget and dead-letters.
+	assert.Equal(t, inbox.Retry, policy(t.Context(), d, cause))
+	assert.Equal(t, inbox.Retry, policy(t.Context(), d, cause))
+	assert.Empty(t, dlq.stored, "not dead-lettered before the budget is exhausted")
+
+	assert.Equal(t, inbox.Skip, policy(t.Context(), d, cause))
+	require.Len(t, dlq.stored, 1)
+	assert.Equal(t, []byte("poison"), dlq.stored[0].Payload)
+	assert.Equal(t, "boom", dlq.stored[0].Error)
+	assert.Equal(t, 3, dlq.stored[0].Attempts)
+}
+
+func TestRetryPolicy_PermanentClassifierDeadLettersImmediately(t *testing.T) {
+	dlq := &fakeDLQ{}
+	permanent := func(err error) bool { return err.Error() == "permanent" }
+	policy := inbox.NewRetryPolicy(dlq, inbox.WithMaxAttempts(5), inbox.WithPermanentClassifier(permanent))
+
+	assert.Equal(t, inbox.Skip, policy(t.Context(), delivery("p"), errors.New("permanent")))
+	require.Len(t, dlq.stored, 1, "permanent error skips the retry budget")
+	assert.Equal(t, 1, dlq.stored[0].Attempts)
+}
+
+func TestRetryPolicy_TransientErrorRetriesUnderClassifier(t *testing.T) {
+	dlq := &fakeDLQ{}
+	permanent := func(err error) bool { return err.Error() == "permanent" }
+	policy := inbox.NewRetryPolicy(dlq, inbox.WithMaxAttempts(3), inbox.WithPermanentClassifier(permanent))
+
+	// A non-permanent error still gets the full retry budget.
+	assert.Equal(t, inbox.Retry, policy(t.Context(), delivery("p"), errors.New("transient")))
+	assert.Empty(t, dlq.stored)
+}
+
+func TestRetryPolicy_CounterResetsOnDifferentRecord(t *testing.T) {
+	dlq := &fakeDLQ{}
+	policy := inbox.NewRetryPolicy(dlq, inbox.WithMaxAttempts(2))
+	cause := errors.New("boom")
+
+	// Interleave two distinct records: each must accrue its own attempt count, so
+	// neither dead-letters on its first failure.
+	assert.Equal(t, inbox.Retry, policy(t.Context(), delivery("a"), cause))
+	assert.Equal(t, inbox.Retry, policy(t.Context(), delivery("b"), cause))
+	assert.Empty(t, dlq.stored)
+
+	// Record "a" fails a second consecutive time → budget (2) exhausted.
+	assert.Equal(t, inbox.Retry, policy(t.Context(), delivery("a"), cause)) // resets: a != last(b)
+	assert.Equal(t, inbox.Skip, policy(t.Context(), delivery("a"), cause))
+	require.Len(t, dlq.stored, 1)
+	assert.Equal(t, []byte("a"), dlq.stored[0].Payload)
+}
+
+func TestRetryPolicy_NilDLQNeverSkips(t *testing.T) {
+	policy := inbox.NewRetryPolicy(nil, inbox.WithMaxAttempts(2))
+	cause := errors.New("boom")
+	d := delivery("poison")
+
+	// Without a sink, an exhausted budget must retry, never drop the record.
+	assert.Equal(t, inbox.Retry, policy(t.Context(), d, cause))
+	assert.Equal(t, inbox.Retry, policy(t.Context(), d, cause))
+	assert.Equal(t, inbox.Retry, policy(t.Context(), d, cause))
+}
+
+func TestRetryPolicy_StoreFailureRetries(t *testing.T) {
+	dlq := &fakeDLQ{failErr: errors.New("db down")}
+	policy := inbox.NewRetryPolicy(dlq, inbox.WithMaxAttempts(1))
+
+	// Budget is 1, so the first failure would dead-letter — but the store fails, so
+	// the record is retried rather than skipped-and-lost.
+	assert.Equal(t, inbox.Retry, policy(t.Context(), delivery("p"), errors.New("boom")))
+}
+
+func TestRetryPolicy_DefaultBudget(t *testing.T) {
+	dlq := &fakeDLQ{}
+	policy := inbox.NewRetryPolicy(dlq) // DefaultMaxAttempts
+	cause := errors.New("boom")
+	d := delivery("poison")
+
+	for i := 1; i < inbox.DefaultMaxAttempts; i++ {
+		assert.Equal(t, inbox.Retry, policy(t.Context(), d, cause))
+	}
+	assert.Equal(t, inbox.Skip, policy(t.Context(), d, cause))
+	assert.Len(t, dlq.stored, 1)
+}
+
+// End-to-end: a poison record redelivered through Consume is retried up to the
+// budget, dead-lettered, and acked so the cursor can advance past it.
+func TestConsume_RetryPolicyDeadLettersPoisonRecord(t *testing.T) {
+	poison := eventBytes(t, "evt-poison")
+	src := &fakeSource{steps: []step{
+		{payload: poison},
+		{payload: poison},
+		{payload: poison},
+	}}
+	handler := func(_ context.Context, _ *pkgregv1.PackageVersionObservationEvent, _ *commonv1.EventMeta) error {
+		return errors.New("boom")
+	}
+
+	dlq := &fakeDLQ{}
+	err := inbox.Consume(t.Context(), src, newObservation, handler,
+		inbox.WithErrorHandler(inbox.NewRetryPolicy(dlq, inbox.WithMaxAttempts(3))),
+	)
+	require.ErrorIs(t, err, context.Canceled)
+
+	assert.Equal(t, 2, src.nacks, "first two attempts retry")
+	assert.Equal(t, 1, src.acks, "third attempt is dead-lettered and acked")
+	require.Len(t, dlq.stored, 1)
+	assert.Equal(t, 3, dlq.stored[0].Attempts)
+}

--- a/events/inbox/retry_test.go
+++ b/events/inbox/retry_test.go
@@ -3,6 +3,7 @@ package inbox_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	commonv1 "buf.build/gen/go/safedep/api/protocolbuffers/go/safedep/events/common/v1"
@@ -56,6 +57,21 @@ func TestRetryPolicy_PermanentClassifierDeadLettersImmediately(t *testing.T) {
 	assert.Equal(t, inbox.Skip, policy(t.Context(), delivery("p"), errors.New("permanent")))
 	require.Len(t, dlq.stored, 1, "permanent error skips the retry budget")
 	assert.Equal(t, 1, dlq.stored[0].Attempts)
+}
+
+func TestRetryPolicy_ClassifierSeesUnwrappedRootCause(t *testing.T) {
+	dlq := &fakeDLQ{}
+	// A message-equality classifier only works if it receives the root cause, not
+	// Consume's wrapped "handler: ..." chain.
+	permanent := func(err error) bool { return err.Error() == "permanent-root" }
+	policy := inbox.NewRetryPolicy(dlq, inbox.WithMaxAttempts(5), inbox.WithPermanentClassifier(permanent))
+
+	wrapped := fmt.Errorf("handler: %w", fmt.Errorf("save investigation: %w", errors.New("permanent-root")))
+	assert.Equal(t, inbox.Skip, policy(t.Context(), delivery("p"), wrapped),
+		"classifier must see the unwrapped root cause and dead-letter immediately")
+	require.Len(t, dlq.stored, 1)
+	// The stored diagnostic keeps the full wrapped chain for triage.
+	assert.Contains(t, dlq.stored[0].Error, "handler:")
 }
 
 func TestRetryPolicy_TransientErrorRetriesUnderClassifier(t *testing.T) {


### PR DESCRIPTION
## Motivation

A malysis production incident: the `internal-events-investigation` feed stalled because one record failed to persist deterministically (a NUL byte in LLM text — Postgres SQLSTATE 22021). The inbox default error policy is `Retry` (Nack → redeliver), so the durable cursor never advanced past the bad record — head-of-line blocking the whole feed and re-reading S2 in a tight loop. The consumer-side data fix shipped separately; this is the durability layer so **no future poison record can stall a feed forever**, regardless of failure class.

The inbox already anticipated this — `inbox.go`: *"A future DLQ is an ErrorHandler that persists `d.Payload` + err and returns Skip — no change to the Consume core."* This PR is exactly that, plus a bounded-retry counter.

## What's added

- **`DeadLetter` model + `DeadLetterQueue` store** (`NewGormDeadLetter`) — persists the raw payload, error, attempt count, and best-effort event_id/feed. Keyed by a **SHA-256 payload fingerprint**, not event_id: a decode failure has no event_id, and a redelivered poison record carries identical bytes, so the fingerprint dedups redeliveries either way. SHA-256 (not a 64-bit hash) so a collision can't make a distinct poison record dedup away and get skipped. Idempotent insert (`OnConflict DoNothing`). Text columns (error/event_id/feed) are sanitized (NUL-stripped, coerced to valid UTF-8) before insert so the diagnostic's own poison can't sink the dead-letter write; the raw record stays verbatim in the `bytea` payload column. Migrated by `inbox.Migrate` alongside `Cursor` / `ProcessedEvent`.
- **`NewRetryPolicy(dlq, opts...)`** — returns an `ErrorHandler` (plugs into the existing `WithErrorHandler` seam; **zero change to `Consume`/`dispose`**). It:
  - retries a failing record up to `WithMaxAttempts(n)` total deliveries (default **4**, so 3 retries), then dead-letters it and returns `Skip`;
  - fast-paths a known-permanent error straight to the DLQ via an optional consumer-supplied `WithPermanentClassifier(func(error) bool)` — the seam for storage/transport-specific knowledge (e.g. a Postgres data-exception SQLSTATE), keeping the generic policy free of it. The classifier receives the unwrapped root cause;
  - **never drops data it hasn't persisted**: if no queue is wired, or the store fails, it retries instead of skipping.

## Design notes

- **Attempt counting is in-memory** over the last-seen fingerprint. `Consume` is single-threaded and a Nack redelivers the same record as the very next `Receive`, so a consecutive-failure counter needs no per-record persistence. It resets on a different record or a process restart; a restart re-grants the budget, which still bounds retries per run and eventually dead-letters a durable poison record. This is the deliberate trade-off vs. a persisted attempt table (documented on `NewRetryPolicy`).
- **The returned handler is stateful and single-use** — one per `Consume` call; documented on `NewRetryPolicy`.
- **Backward compatible**: default `Consume` (no error-handler option) behaves exactly as before — infinite `Retry`. Consumers opt in per feed.

## Tests

- `deadletter_test.go` — store persistence, payload-based idempotency, per-consumer isolation, empty-payload guard, text sanitization (with verbatim payload), constructor validation, `Migrate` idempotency (sqlite adapter, same helper as the cursor/dedup tests).
- `retry_test.go` — retry-until-budget → dead-letter; permanent-classifier immediate dead-letter; unwrapped-root-cause classification; transient error keeps its budget; counter resets across interleaved records; nil-DLQ never skips; store-failure retries; default budget; and an end-to-end `Consume` test driving a poison record through retry → dead-letter → ack.

## Follow-up (not in this PR)

DLQ **read/admin primitives** — `List` / `Get` / `Delete` and a generic `Replay[T]` helper (reusing `newEvent`/`Handler[T]`) — so consumers can build thin `... events dlq {list,replay}` CLIs without re-querying DRY's schema. Kept separate so this incident fix stays small.

## Downstream

malysis wires this in its `runFeed` (a follow-up PR bumps the `dry` pin and supplies a Postgres `IsPermanentDataError` classifier). No other current consumer changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193wYMcXKtDNsbhv8VVDEyR