### PR TITLE
feat(inbox): dead-letter read + replay for parked records

### DIFF
--- a/events/inbox/deadletter.go
+++ b/events/inbox/deadletter.go
@@ -66,10 +66,10 @@ type gormDeadLetter struct {
 
 var _ DeadLetterQueue = &gormDeadLetter{}
 
-// NewGormDeadLetter builds a consumer-scoped DeadLetterQueue over the consumer's
-// SQL adapter. The consumer name is bound here so Store stays keyless, mirroring
-// NewGormDedup.
-func NewGormDeadLetter(adapter db.SqlDataAdapter, consumerName string) (DeadLetterQueue, error) {
+// newGormDeadLetter builds the consumer-scoped gorm store both the write
+// (DeadLetterQueue) and read (DeadLetterReader) sides share, so their validation
+// stays in one place.
+func newGormDeadLetter(adapter db.SqlDataAdapter, consumerName string) (*gormDeadLetter, error) {
 	if adapter == nil {
 		return nil, fmt.Errorf("inbox: dead-letter queue: adapter is required")
 	}
@@ -82,6 +82,13 @@ func NewGormDeadLetter(adapter db.SqlDataAdapter, consumerName string) (DeadLett
 		return nil, fmt.Errorf("inbox: dead-letter queue: %w", err)
 	}
 	return &gormDeadLetter{db: gdb, consumerName: consumerName}, nil
+}
+
+// NewGormDeadLetter builds a consumer-scoped DeadLetterQueue over the consumer's
+// SQL adapter. The consumer name is bound here so Store stays keyless, mirroring
+// NewGormDedup.
+func NewGormDeadLetter(adapter db.SqlDataAdapter, consumerName string) (DeadLetterQueue, error) {
+	return newGormDeadLetter(adapter, consumerName)
 }
 
 func (q *gormDeadLetter) Store(ctx context.Context, rec DeadLetterRecord) error {

--- a/events/inbox/deadletter_reader.go
+++ b/events/inbox/deadletter_reader.go
@@ -1,0 +1,124 @@
+package inbox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/safedep/dry/db"
+	"gorm.io/gorm"
+)
+
+// defaultDeadLetterPageSize bounds a List page when the caller does not set one.
+// It also serves as Replay's internal page size while it drains a backlog.
+const defaultDeadLetterPageSize = 100
+
+// ErrDeadLetterNotFound is returned by DeadLetterReader.Get when no record with
+// the id exists for this consumer. Mirrors ErrNoCursor: an exported sentinel so
+// callers distinguish "not there" from a query failure.
+var ErrDeadLetterNotFound = errors.New("inbox: dead-letter record not found")
+
+// DeadLetterFilter narrows a List / Count. All fields are optional; a zero filter
+// matches every record for the consumer. Feed / EventID / Before select records;
+// AfterID / Limit page over them (id-ordered, ascending). Count ignores AfterID
+// and Limit — it answers "how many match the selection", not "how many on a page".
+type DeadLetterFilter struct {
+	Feed    string
+	EventID string
+	Before  time.Time // failed_at strictly before this instant
+	AfterID uint64    // cursor: records with id greater than this
+	Limit   int       // page size; <= 0 uses defaultDeadLetterPageSize
+}
+
+// DeadLetterReader is the read/replay dual of DeadLetterQueue: it lists, fetches,
+// counts, and deletes the records the write side has parked. It is consumer-scoped
+// like the writer, so an operator can never list or replay another consumer's
+// records through it (replaying bytes under the wrong typed handler is the footgun
+// the scoping removes).
+type DeadLetterReader interface {
+	// List returns one id-ordered page of records matching f (ascending id). Use
+	// f.AfterID = the last id seen to page forward.
+	List(ctx context.Context, f DeadLetterFilter) ([]DeadLetter, error)
+	// Get fetches one record by id, or ErrDeadLetterNotFound.
+	Get(ctx context.Context, id uint64) (*DeadLetter, error)
+	// Count returns how many records match f's selection (AfterID / Limit ignored).
+	Count(ctx context.Context, f DeadLetterFilter) (int64, error)
+	// Delete removes one record by id. It is idempotent: deleting a record that is
+	// already gone is not an error, so a replay that deletes after a successful
+	// handler never races a concurrent purge into a failure.
+	Delete(ctx context.Context, id uint64) error
+}
+
+var _ DeadLetterReader = &gormDeadLetter{}
+
+// NewGormDeadLetterReader builds a consumer-scoped DeadLetterReader over the
+// consumer's SQL adapter. Same validation and scoping as NewGormDeadLetter.
+func NewGormDeadLetterReader(adapter db.SqlDataAdapter, consumerName string) (DeadLetterReader, error) {
+	return newGormDeadLetter(adapter, consumerName)
+}
+
+// selection applies the consumer scope and content filters (Feed / EventID /
+// Before), the predicates shared by List and Count. Pagination (AfterID / Limit)
+// is layered on by List only.
+func (q *gormDeadLetter) selection(tx *gorm.DB, f DeadLetterFilter) *gorm.DB {
+	tx = tx.Where("consumer_name = ?", q.consumerName)
+	if f.Feed != "" {
+		tx = tx.Where("feed = ?", f.Feed)
+	}
+	if f.EventID != "" {
+		tx = tx.Where("event_id = ?", f.EventID)
+	}
+	if !f.Before.IsZero() {
+		tx = tx.Where("failed_at < ?", f.Before)
+	}
+	return tx
+}
+
+func (q *gormDeadLetter) List(ctx context.Context, f DeadLetterFilter) ([]DeadLetter, error) {
+	limit := f.Limit
+	if limit <= 0 {
+		limit = defaultDeadLetterPageSize
+	}
+	tx := q.selection(q.db.WithContext(ctx), f)
+	if f.AfterID > 0 {
+		tx = tx.Where("id > ?", f.AfterID)
+	}
+	var rows []DeadLetter
+	if err := tx.Order("id").Limit(limit).Find(&rows).Error; err != nil {
+		return nil, fmt.Errorf("inbox: dead-letter list: %w", err)
+	}
+	return rows, nil
+}
+
+func (q *gormDeadLetter) Get(ctx context.Context, id uint64) (*DeadLetter, error) {
+	var row DeadLetter
+	err := q.db.WithContext(ctx).
+		Where("consumer_name = ? AND id = ?", q.consumerName, id).
+		First(&row).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, ErrDeadLetterNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("inbox: dead-letter get: %w", err)
+	}
+	return &row, nil
+}
+
+func (q *gormDeadLetter) Count(ctx context.Context, f DeadLetterFilter) (int64, error) {
+	var n int64
+	if err := q.selection(q.db.WithContext(ctx).Model(&DeadLetter{}), f).Count(&n).Error; err != nil {
+		return 0, fmt.Errorf("inbox: dead-letter count: %w", err)
+	}
+	return n, nil
+}
+
+func (q *gormDeadLetter) Delete(ctx context.Context, id uint64) error {
+	err := q.db.WithContext(ctx).
+		Where("consumer_name = ? AND id = ?", q.consumerName, id).
+		Delete(&DeadLetter{}).Error
+	if err != nil {
+		return fmt.Errorf("inbox: dead-letter delete: %w", err)
+	}
+	return nil
+}

--- a/events/inbox/deadletter_reader_test.go
+++ b/events/inbox/deadletter_reader_test.go
@@ -1,0 +1,176 @@
+package inbox_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/safedep/dry/db"
+	"github.com/safedep/dry/events/inbox"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewGormDeadLetterReader_Validation(t *testing.T) {
+	_, err := inbox.NewGormDeadLetterReader(nil, "c")
+	require.Error(t, err, "nil adapter is rejected")
+
+	_, err = inbox.NewGormDeadLetterReader(newTestAdapter(t), "")
+	require.Error(t, err, "empty consumer name is rejected")
+}
+
+// seedDeadLetter stores one record for consumerName and returns the whole store,
+// so a test can seed then read through the reader.
+func seedDeadLetter(t *testing.T, adapter db.SqlDataAdapter, consumerName string, recs ...inbox.DeadLetterRecord) {
+	t.Helper()
+	w, err := inbox.NewGormDeadLetter(adapter, consumerName)
+	require.NoError(t, err)
+	for _, r := range recs {
+		require.NoError(t, w.Store(t.Context(), r))
+	}
+}
+
+func TestDeadLetterReader_ListIsScopedAndOrdered(t *testing.T) {
+	adapter := newTestAdapter(t)
+	seedDeadLetter(t, adapter, "consumer-a",
+		inbox.DeadLetterRecord{Payload: []byte("a1"), Feed: "feed.X", EventID: "e1"},
+		inbox.DeadLetterRecord{Payload: []byte("a2"), Feed: "feed.Y", EventID: "e2"},
+	)
+	seedDeadLetter(t, adapter, "consumer-b",
+		inbox.DeadLetterRecord{Payload: []byte("b1"), Feed: "feed.X"},
+	)
+
+	reader, err := inbox.NewGormDeadLetterReader(adapter, "consumer-a")
+	require.NoError(t, err)
+
+	rows, err := reader.List(t.Context(), inbox.DeadLetterFilter{})
+	require.NoError(t, err)
+	require.Len(t, rows, 2, "only consumer-a's records, not consumer-b's")
+	assert.Less(t, rows[0].ID, rows[1].ID, "ascending id order")
+	assert.Equal(t, []byte("a1"), rows[0].Payload)
+}
+
+func TestDeadLetterReader_FiltersFeedAndEventID(t *testing.T) {
+	adapter := newTestAdapter(t)
+	seedDeadLetter(t, adapter, "consumer-a",
+		inbox.DeadLetterRecord{Payload: []byte("a1"), Feed: "feed.X", EventID: "e1"},
+		inbox.DeadLetterRecord{Payload: []byte("a2"), Feed: "feed.Y", EventID: "e2"},
+	)
+	reader, err := inbox.NewGormDeadLetterReader(adapter, "consumer-a")
+	require.NoError(t, err)
+
+	byFeed, err := reader.List(t.Context(), inbox.DeadLetterFilter{Feed: "feed.Y"})
+	require.NoError(t, err)
+	require.Len(t, byFeed, 1)
+	assert.Equal(t, "e2", byFeed[0].EventID)
+
+	byEvent, err := reader.List(t.Context(), inbox.DeadLetterFilter{EventID: "e1"})
+	require.NoError(t, err)
+	require.Len(t, byEvent, 1)
+	assert.Equal(t, []byte("a1"), byEvent[0].Payload)
+}
+
+func TestDeadLetterReader_FiltersBefore(t *testing.T) {
+	adapter := newTestAdapter(t)
+	gdb, err := adapter.GetDB()
+	require.NoError(t, err)
+
+	old := time.Now().Add(-2 * time.Hour)
+	recent := time.Now()
+	// Insert directly to control failed_at.
+	require.NoError(t, gdb.Create(&inbox.DeadLetter{
+		ConsumerName: "consumer-a", PayloadHash: "h-old", Payload: []byte("old"), FailedAt: old,
+	}).Error)
+	require.NoError(t, gdb.Create(&inbox.DeadLetter{
+		ConsumerName: "consumer-a", PayloadHash: "h-new", Payload: []byte("new"), FailedAt: recent,
+	}).Error)
+
+	reader, err := inbox.NewGormDeadLetterReader(adapter, "consumer-a")
+	require.NoError(t, err)
+
+	rows, err := reader.List(t.Context(), inbox.DeadLetterFilter{Before: time.Now().Add(-1 * time.Hour)})
+	require.NoError(t, err)
+	require.Len(t, rows, 1, "only the record older than the cutoff")
+	assert.Equal(t, []byte("old"), rows[0].Payload)
+}
+
+func TestDeadLetterReader_PaginatesByAfterID(t *testing.T) {
+	adapter := newTestAdapter(t)
+	seedDeadLetter(t, adapter, "consumer-a",
+		inbox.DeadLetterRecord{Payload: []byte("a1")},
+		inbox.DeadLetterRecord{Payload: []byte("a2")},
+		inbox.DeadLetterRecord{Payload: []byte("a3")},
+	)
+	reader, err := inbox.NewGormDeadLetterReader(adapter, "consumer-a")
+	require.NoError(t, err)
+
+	page1, err := reader.List(t.Context(), inbox.DeadLetterFilter{Limit: 2})
+	require.NoError(t, err)
+	require.Len(t, page1, 2)
+
+	page2, err := reader.List(t.Context(), inbox.DeadLetterFilter{Limit: 2, AfterID: page1[1].ID})
+	require.NoError(t, err)
+	require.Len(t, page2, 1, "one record left after the first page")
+	assert.Greater(t, page2[0].ID, page1[1].ID)
+}
+
+func TestDeadLetterReader_CountIgnoresPagination(t *testing.T) {
+	adapter := newTestAdapter(t)
+	seedDeadLetter(t, adapter, "consumer-a",
+		inbox.DeadLetterRecord{Payload: []byte("a1"), Feed: "feed.X"},
+		inbox.DeadLetterRecord{Payload: []byte("a2"), Feed: "feed.X"},
+		inbox.DeadLetterRecord{Payload: []byte("a3"), Feed: "feed.Y"},
+	)
+	reader, err := inbox.NewGormDeadLetterReader(adapter, "consumer-a")
+	require.NoError(t, err)
+
+	all, err := reader.Count(t.Context(), inbox.DeadLetterFilter{Limit: 1, AfterID: 999})
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), all, "Count ignores AfterID/Limit")
+
+	byFeed, err := reader.Count(t.Context(), inbox.DeadLetterFilter{Feed: "feed.X"})
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), byFeed)
+}
+
+func TestDeadLetterReader_GetAndScopedNotFound(t *testing.T) {
+	adapter := newTestAdapter(t)
+	seedDeadLetter(t, adapter, "consumer-a", inbox.DeadLetterRecord{Payload: []byte("a1")})
+	seedDeadLetter(t, adapter, "consumer-b", inbox.DeadLetterRecord{Payload: []byte("b1")})
+
+	readerA, err := inbox.NewGormDeadLetterReader(adapter, "consumer-a")
+	require.NoError(t, err)
+	rows, err := readerA.List(t.Context(), inbox.DeadLetterFilter{})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	aID := rows[0].ID
+
+	got, err := readerA.Get(t.Context(), aID)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("a1"), got.Payload)
+
+	// consumer-b's reader must not see consumer-a's record by id.
+	readerB, err := inbox.NewGormDeadLetterReader(adapter, "consumer-b")
+	require.NoError(t, err)
+	_, err = readerB.Get(t.Context(), aID)
+	require.ErrorIs(t, err, inbox.ErrDeadLetterNotFound)
+}
+
+func TestDeadLetterReader_DeleteIsScopedAndIdempotent(t *testing.T) {
+	adapter := newTestAdapter(t)
+	seedDeadLetter(t, adapter, "consumer-a", inbox.DeadLetterRecord{Payload: []byte("a1")})
+	reader, err := inbox.NewGormDeadLetterReader(adapter, "consumer-a")
+	require.NoError(t, err)
+
+	rows, err := reader.List(t.Context(), inbox.DeadLetterFilter{})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	id := rows[0].ID
+
+	require.NoError(t, reader.Delete(t.Context(), id))
+	// Idempotent: deleting the now-gone record is not an error.
+	require.NoError(t, reader.Delete(t.Context(), id))
+
+	n, err := reader.Count(t.Context(), inbox.DeadLetterFilter{})
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n)
+}

--- a/events/inbox/replay.go
+++ b/events/inbox/replay.go
@@ -66,6 +66,9 @@ func Replay[T proto.Message](
 	var res ReplayResult
 	afterID := f.AfterID
 	for {
+		if err := ctx.Err(); err != nil {
+			return res, err
+		}
 		page := f
 		page.AfterID = afterID
 		rows, err := reader.List(ctx, page)
@@ -76,6 +79,12 @@ func Replay[T proto.Message](
 			return res, nil
 		}
 		for i := range rows {
+			// Stop before touching the next buffered row once the caller cancels:
+			// otherwise a context-unaware handler runs side effects past the cancel
+			// while the context-aware delete fails and re-parks the row.
+			if err := ctx.Err(); err != nil {
+				return res, err
+			}
 			row := rows[i]
 			// Advance the cursor past every row we touch, including failures, so a
 			// permanently-failing record is not re-listed on the next page — that

--- a/events/inbox/replay.go
+++ b/events/inbox/replay.go
@@ -1,0 +1,120 @@
+package inbox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/safedep/dry/events"
+	"google.golang.org/protobuf/proto"
+)
+
+// ReplayOutcome is the result for one dead-letter record. Err is nil when the
+// record was reprocessed and removed; otherwise it is the decode / envelope /
+// handler failure that kept the record parked.
+type ReplayOutcome struct {
+	ID      uint64
+	EventID string
+	Err     error
+}
+
+// ReplayResult summarises a Replay run. Outcomes is per-record, in id order.
+type ReplayResult struct {
+	Succeeded int
+	Failed    int
+	Outcomes  []ReplayOutcome
+}
+
+// Replay feeds each parked record's raw bytes back through the original decode →
+// envelope → handler path — the same ladder Consume uses — and deletes the record
+// when the handler succeeds. It drains every record matching f, paging internally
+// (f.Limit is the page size), and returns a per-record summary.
+//
+// A record only clears if the handler can now process bytes it previously could
+// not: the earlier failure was transient (e.g. the store was down), or a code
+// change now handles them (e.g. a consumer that now sanitizes a byte its schema
+// rejects). A record that is permanently poison — no code change makes it
+// processable — fails replay again and stays parked; purge it via
+// DeadLetterReader.Delete. Replay never re-parks a failed record it already saw:
+// it pages by advancing past the highest id seen, failures included, so the drain
+// always terminates.
+//
+// The handler runs with the same at-least-once, must-be-idempotent contract as in
+// Consume. A List error aborts and is returned; a single record's failure is
+// recorded in its outcome and does not stop the run.
+func Replay[T proto.Message](
+	ctx context.Context,
+	reader DeadLetterReader,
+	newEvent func() T,
+	handler Handler[T],
+	f DeadLetterFilter,
+) (ReplayResult, error) {
+	if reader == nil {
+		return ReplayResult{}, errors.New("inbox: replay: reader is required")
+	}
+	if newEvent == nil {
+		return ReplayResult{}, errors.New("inbox: replay: newEvent constructor is required")
+	}
+	if handler == nil {
+		return ReplayResult{}, errors.New("inbox: replay: handler is required")
+	}
+	// Same fail-fast as Consume: a nil message would panic proto.Unmarshal.
+	if nilMessage(newEvent()) {
+		return ReplayResult{}, errors.New("inbox: replay: newEvent must return a non-nil message")
+	}
+
+	var res ReplayResult
+	afterID := f.AfterID
+	for {
+		page := f
+		page.AfterID = afterID
+		rows, err := reader.List(ctx, page)
+		if err != nil {
+			return res, fmt.Errorf("inbox: replay: %w", err)
+		}
+		if len(rows) == 0 {
+			return res, nil
+		}
+		for i := range rows {
+			row := rows[i]
+			// Advance the cursor past every row we touch, including failures, so a
+			// permanently-failing record is not re-listed on the next page — that
+			// would loop forever.
+			if row.ID > afterID {
+				afterID = row.ID
+			}
+			out := ReplayOutcome{ID: row.ID, EventID: row.EventID}
+			if err := replayOne(ctx, reader, row, newEvent, handler); err != nil {
+				out.Err = err
+				res.Failed++
+			} else {
+				res.Succeeded++
+			}
+			res.Outcomes = append(res.Outcomes, out)
+		}
+	}
+}
+
+func replayOne[T proto.Message](
+	ctx context.Context,
+	reader DeadLetterReader,
+	row DeadLetter,
+	newEvent func() T,
+	handler Handler[T],
+) error {
+	event := newEvent()
+	if err := proto.Unmarshal(row.Payload, event); err != nil {
+		return fmt.Errorf("decode: %w", err)
+	}
+	meta, err := events.MetaOf(event)
+	if err != nil {
+		return fmt.Errorf("envelope: %w", err)
+	}
+	if err := handler(ctx, event, meta); err != nil {
+		return fmt.Errorf("handler: %w", err)
+	}
+	if err := reader.Delete(ctx, row.ID); err != nil {
+		return fmt.Errorf("delete after replay: %w", err)
+	}
+	return nil
+}

--- a/events/inbox/replay_test.go
+++ b/events/inbox/replay_test.go
@@ -164,6 +164,57 @@ func TestReplay_DrainsAllPages(t *testing.T) {
 	assert.Equal(t, int64(0), n)
 }
 
+func TestReplay_AlreadyCancelledContextDoesNothing(t *testing.T) {
+	adapter := newTestAdapter(t)
+	seedDeadLetter(t, adapter, "consumer-a", inbox.DeadLetterRecord{Payload: eventBytes(t, "e1"), EventID: "e1"})
+	reader := newDeadLetterReader(t, adapter, "consumer-a")
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	called := false
+	handler := func(_ context.Context, _ *pkgregv1.PackageVersionObservationEvent, _ *commonv1.EventMeta) error {
+		called = true
+		return nil
+	}
+
+	res, err := inbox.Replay(ctx, reader, newObservation, handler, inbox.DeadLetterFilter{})
+	require.ErrorIs(t, err, context.Canceled)
+	assert.False(t, called, "no handler runs under an already-cancelled context")
+	assert.Equal(t, 0, res.Succeeded)
+
+	n, err := reader.Count(t.Context(), inbox.DeadLetterFilter{})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n, "the record stays parked")
+}
+
+// Cancelling mid-drain stops before the next buffered row: a context-unaware
+// handler must not keep running side effects after the caller cancels.
+func TestReplay_StopsMidPageOnCancellation(t *testing.T) {
+	adapter := newTestAdapter(t)
+	seedDeadLetter(t, adapter, "consumer-a",
+		inbox.DeadLetterRecord{Payload: eventBytes(t, "e1"), EventID: "e1"},
+		inbox.DeadLetterRecord{Payload: eventBytes(t, "e2"), EventID: "e2"},
+		inbox.DeadLetterRecord{Payload: eventBytes(t, "e3"), EventID: "e3"},
+	)
+	reader := newDeadLetterReader(t, adapter, "consumer-a")
+
+	// Default limit pulls all three into one page, so the per-row guard — not a
+	// List error on the next page — is what stops the loop.
+	ctx, cancel := context.WithCancel(t.Context())
+	count := 0
+	handler := func(_ context.Context, _ *pkgregv1.PackageVersionObservationEvent, _ *commonv1.EventMeta) error {
+		count++
+		cancel()
+		return nil
+	}
+
+	res, err := inbox.Replay(ctx, reader, newObservation, handler, inbox.DeadLetterFilter{})
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, count, "handler runs for the cancelling row, then the loop stops")
+	assert.Len(t, res.Outcomes, 1, "no outcome recorded for the skipped rows")
+}
+
 // A permanently-failing record between good ones must not stall the drain: Replay
 // advances past it (rather than re-listing it forever) and still clears the rest.
 func TestReplay_AdvancesPastPersistentFailure(t *testing.T) {

--- a/events/inbox/replay_test.go
+++ b/events/inbox/replay_test.go
@@ -1,0 +1,191 @@
+package inbox_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	commonv1 "buf.build/gen/go/safedep/api/protocolbuffers/go/safedep/events/common/v1"
+	pkgregv1 "buf.build/gen/go/safedep/api/protocolbuffers/go/safedep/events/private/packageregistry/v1"
+	"github.com/safedep/dry/db"
+	"github.com/safedep/dry/events/inbox"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newDeadLetterReader(t *testing.T, adapter db.SqlDataAdapter, consumerName string) inbox.DeadLetterReader {
+	t.Helper()
+	r, err := inbox.NewGormDeadLetterReader(adapter, consumerName)
+	require.NoError(t, err)
+	return r
+}
+
+func TestReplay_Validation(t *testing.T) {
+	reader := newDeadLetterReader(t, newTestAdapter(t), "consumer-a")
+	ok := func(_ context.Context, _ *pkgregv1.PackageVersionObservationEvent, _ *commonv1.EventMeta) error {
+		return nil
+	}
+
+	_, err := inbox.Replay(t.Context(), nil, newObservation, ok, inbox.DeadLetterFilter{})
+	require.Error(t, err, "nil reader")
+
+	_, err = inbox.Replay[*pkgregv1.PackageVersionObservationEvent](t.Context(), reader, nil, ok, inbox.DeadLetterFilter{})
+	require.Error(t, err, "nil newEvent")
+
+	_, err = inbox.Replay(t.Context(), reader, newObservation, nil, inbox.DeadLetterFilter{})
+	require.Error(t, err, "nil handler")
+
+	boxedNil := func() *pkgregv1.PackageVersionObservationEvent { return nil }
+	_, err = inbox.Replay(t.Context(), reader, boxedNil, ok, inbox.DeadLetterFilter{})
+	require.Error(t, err, "newEvent returning a nil message")
+}
+
+func TestReplay_SucceedsAndDeletes(t *testing.T) {
+	adapter := newTestAdapter(t)
+	seedDeadLetter(t, adapter, "consumer-a", inbox.DeadLetterRecord{
+		Payload: eventBytes(t, "evt-1"), Feed: "feed.X", EventID: "evt-1",
+	})
+	reader := newDeadLetterReader(t, adapter, "consumer-a")
+
+	var seen []string
+	handler := func(_ context.Context, _ *pkgregv1.PackageVersionObservationEvent, meta *commonv1.EventMeta) error {
+		seen = append(seen, meta.GetEventId())
+		return nil
+	}
+
+	res, err := inbox.Replay(t.Context(), reader, newObservation, handler, inbox.DeadLetterFilter{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, res.Succeeded)
+	assert.Equal(t, 0, res.Failed)
+	require.Len(t, res.Outcomes, 1)
+	assert.NoError(t, res.Outcomes[0].Err)
+	assert.Equal(t, []string{"evt-1"}, seen)
+
+	n, err := reader.Count(t.Context(), inbox.DeadLetterFilter{})
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n, "a replayed record is removed")
+}
+
+func TestReplay_HandlerFailureKeepsRow(t *testing.T) {
+	adapter := newTestAdapter(t)
+	seedDeadLetter(t, adapter, "consumer-a", inbox.DeadLetterRecord{
+		Payload: eventBytes(t, "evt-1"), EventID: "evt-1",
+	})
+	reader := newDeadLetterReader(t, adapter, "consumer-a")
+
+	handler := func(_ context.Context, _ *pkgregv1.PackageVersionObservationEvent, _ *commonv1.EventMeta) error {
+		return errors.New("still failing")
+	}
+
+	res, err := inbox.Replay(t.Context(), reader, newObservation, handler, inbox.DeadLetterFilter{})
+	require.NoError(t, err)
+	assert.Equal(t, 0, res.Succeeded)
+	assert.Equal(t, 1, res.Failed)
+	require.Len(t, res.Outcomes, 1)
+	require.Error(t, res.Outcomes[0].Err)
+	assert.Contains(t, res.Outcomes[0].Err.Error(), "handler")
+
+	n, err := reader.Count(t.Context(), inbox.DeadLetterFilter{})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n, "a record whose handler still fails stays parked")
+}
+
+func TestReplay_DecodeFailureKeepsRow(t *testing.T) {
+	adapter := newTestAdapter(t)
+	// A truncated varint tag: proto.Unmarshal cannot decode it. This is the
+	// decode-poison class a generic dead-letter never gets an event_id for.
+	seedDeadLetter(t, adapter, "consumer-a", inbox.DeadLetterRecord{Payload: []byte{0xff}})
+	reader := newDeadLetterReader(t, adapter, "consumer-a")
+
+	called := false
+	handler := func(_ context.Context, _ *pkgregv1.PackageVersionObservationEvent, _ *commonv1.EventMeta) error {
+		called = true
+		return nil
+	}
+
+	res, err := inbox.Replay(t.Context(), reader, newObservation, handler, inbox.DeadLetterFilter{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, res.Failed)
+	assert.False(t, called, "handler is not reached when the payload cannot decode")
+	require.Len(t, res.Outcomes, 1)
+	assert.Contains(t, res.Outcomes[0].Err.Error(), "decode")
+
+	n, err := reader.Count(t.Context(), inbox.DeadLetterFilter{})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n)
+}
+
+func TestReplay_ScopedToConsumer(t *testing.T) {
+	adapter := newTestAdapter(t)
+	seedDeadLetter(t, adapter, "consumer-a", inbox.DeadLetterRecord{Payload: eventBytes(t, "a"), EventID: "a"})
+	seedDeadLetter(t, adapter, "consumer-b", inbox.DeadLetterRecord{Payload: eventBytes(t, "b"), EventID: "b"})
+
+	var seen []string
+	handler := func(_ context.Context, _ *pkgregv1.PackageVersionObservationEvent, meta *commonv1.EventMeta) error {
+		seen = append(seen, meta.GetEventId())
+		return nil
+	}
+
+	res, err := inbox.Replay(t.Context(), newDeadLetterReader(t, adapter, "consumer-a"),
+		newObservation, handler, inbox.DeadLetterFilter{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, res.Succeeded)
+	assert.Equal(t, []string{"a"}, seen, "only consumer-a's record replayed")
+
+	// consumer-b's record is untouched.
+	nB, err := newDeadLetterReader(t, adapter, "consumer-b").Count(t.Context(), inbox.DeadLetterFilter{})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), nB)
+}
+
+func TestReplay_DrainsAllPages(t *testing.T) {
+	adapter := newTestAdapter(t)
+	seedDeadLetter(t, adapter, "consumer-a",
+		inbox.DeadLetterRecord{Payload: eventBytes(t, "e1"), EventID: "e1"},
+		inbox.DeadLetterRecord{Payload: eventBytes(t, "e2"), EventID: "e2"},
+		inbox.DeadLetterRecord{Payload: eventBytes(t, "e3"), EventID: "e3"},
+	)
+	reader := newDeadLetterReader(t, adapter, "consumer-a")
+
+	count := 0
+	handler := func(_ context.Context, _ *pkgregv1.PackageVersionObservationEvent, _ *commonv1.EventMeta) error {
+		count++
+		return nil
+	}
+
+	// Limit 1 forces the internal drain loop to page across every record.
+	res, err := inbox.Replay(t.Context(), reader, newObservation, handler, inbox.DeadLetterFilter{Limit: 1})
+	require.NoError(t, err)
+	assert.Equal(t, 3, res.Succeeded)
+	assert.Equal(t, 3, count)
+
+	n, err := reader.Count(t.Context(), inbox.DeadLetterFilter{})
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n)
+}
+
+// A permanently-failing record between good ones must not stall the drain: Replay
+// advances past it (rather than re-listing it forever) and still clears the rest.
+func TestReplay_AdvancesPastPersistentFailure(t *testing.T) {
+	adapter := newTestAdapter(t)
+	seedDeadLetter(t, adapter, "consumer-a",
+		inbox.DeadLetterRecord{Payload: eventBytes(t, "e1"), EventID: "e1"},
+		inbox.DeadLetterRecord{Payload: []byte{0xff}}, // never decodes
+		inbox.DeadLetterRecord{Payload: eventBytes(t, "e3"), EventID: "e3"},
+	)
+	reader := newDeadLetterReader(t, adapter, "consumer-a")
+
+	handler := func(_ context.Context, _ *pkgregv1.PackageVersionObservationEvent, _ *commonv1.EventMeta) error {
+		return nil
+	}
+
+	// Limit 1 makes the poison record its own page; the drain must still terminate.
+	res, err := inbox.Replay(t.Context(), reader, newObservation, handler, inbox.DeadLetterFilter{Limit: 1})
+	require.NoError(t, err)
+	assert.Equal(t, 2, res.Succeeded)
+	assert.Equal(t, 1, res.Failed)
+
+	remaining, err := reader.Count(t.Context(), inbox.DeadLetterFilter{})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), remaining, "only the undecodable record stays parked")
+}


### PR DESCRIPTION
## Motivation

Follow-up to #145. The write side parks poison records in `event_inbox_dead_letter` so a feed can advance past one un-persistable record instead of stalling. This PR adds the **read/replay dual** so an operator can inspect that backlog and drain it once the cause is resolved — the piece tracked as the DLQ read/replay follow-up.

Library-only change in `github.com/safedep/dry/events/inbox`. The consumer-side CLI (`… events dlq list|show|replay|purge`) lands separately in the downstream consumer; this PR is the reusable primitive it builds on.

## What changed

### `DeadLetterReader` — inspect the backlog
`List` (filter by feed / event_id / failed-at, id-paged via `AfterID`), `Get`, `Count`, `Delete`. Consumer-scoped exactly like `NewGormDeadLetter`, so records can never be listed or replayed under **another** consumer's handler — replaying bytes through the wrong typed handler is the footgun the scoping removes. Both sides share one gorm store through an extracted `newGormDeadLetter` builder, so validation and scoping stay in one place. `Delete` is idempotent (deleting an already-gone record is not an error) so a replay that deletes after a successful handler never races a concurrent purge into a failure.

### `Replay[T]` — reprocess parked records
Feeds each parked record's raw bytes back through the **same** `decode → envelope → handler` ladder `Consume` uses, and deletes the record when the handler succeeds. It drains every record matching the filter, paging internally (`Limit` is the page size) and advancing the cursor past every row it touches — **failures included** — so a permanently-poison record can't loop the drain. A single record's failure is captured in its `ReplayOutcome` and never aborts the run; only a `List` error aborts.

The important semantic, documented on the function: **a record only clears if the handler can now process bytes it previously could not** — the earlier failure was transient (store was down), or a code change now handles them (e.g. a consumer that now sanitizes a byte its schema rejects). A record that is permanently poison fails replay again and stays parked; an operator purges it via `DeadLetterReader.Delete`. The handler keeps the same at-least-once, must-be-idempotent contract as in `Consume`.

### `ErrDeadLetterNotFound`
Exported sentinel from `Get`, mirroring `ErrNoCursor`, so callers distinguish "not there" from a query failure.

## Not included / by design

- **No schema change.** v1 deletes on successful replay — the record is back in the projection via the handler, so the DLQ row is redundant. An audit trail (a `replayed_at` / status column, soft-mark instead of delete) is a deliberate follow-up, not silently assumed here.
- **No change to the write path.** `DeadLetterQueue` (just `Store`) and `NewRetryPolicy` are untouched; the reader is a separate interface (ISP), satisfied by the same gorm type.

## Tests

cgo-free, sqlite-backed like the existing inbox tests.

- Reader: consumer scoping, feed / event_id / before filters, id pagination, `Count` ignoring pagination, scoped `Get` not-found, idempotent `Delete`.
- Replay: success-and-delete, handler-failure-keeps-row, decode-failure-keeps-row, consumer scoping, multi-page drain (`Limit: 1`), and advance-past-persistent-failure (proves the drain terminates rather than re-listing poison).

`go build ./…`, `go vet`, `go test ./events/inbox/…`, `gofmt`, and `golangci-lint run ./events/inbox/…` are clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193wYMcXKtDNsbhv8VVDEyR

---
_Generated by [Claude Code](https://claude.ai/code/session_0193wYMcXKtDNsbhv8VVDEyR)_