### PR TITLE
feat(inbox): pace redeliveries of a failing record with exponential backoff

### DIFF
--- a/events/inbox/backoff.go
+++ b/events/inbox/backoff.go
@@ -1,0 +1,46 @@
+package inbox
+
+import "time"
+
+// redeliveryBackoff paces repeated redeliveries of one failing record, keyed by
+// the record's payload fingerprint. The first redelivery is immediate, so a
+// one-off transient failure costs no latency; consecutive redeliveries of the
+// same record then wait base, 2*base, ... capped at max. A different record or
+// a reset clears the escalation.
+//
+// This bounds poison-record read amplification at the source: on S2 every
+// redelivery reopens a streaming read session at the stalled cursor and the
+// server re-pushes the backlog behind it, so unpaced retries of a permanently
+// failing record turn into unbounded metered reads.
+type redeliveryBackoff struct {
+	base, max time.Duration
+	key       string
+	delay     time.Duration
+}
+
+// next reports how long to wait before redelivering the record identified by
+// key: zero for its first redelivery, then base doubling up to max.
+func (b *redeliveryBackoff) next(key string) time.Duration {
+	if key != b.key {
+		b.key = key
+		b.delay = 0
+		return 0
+	}
+
+	switch {
+	case b.delay == 0:
+		b.delay = b.base
+	case b.delay >= b.max/2:
+		// Doubling would overshoot the cap (or overflow the duration).
+		b.delay = b.max
+	default:
+		b.delay *= 2
+	}
+
+	return b.delay
+}
+
+func (b *redeliveryBackoff) reset() {
+	b.key = ""
+	b.delay = 0
+}

--- a/events/inbox/backoff.go
+++ b/events/inbox/backoff.go
@@ -8,6 +8,11 @@ import "time"
 // same record then wait base, 2*base, ... capped at max. A different record or
 // a reset clears the escalation.
 //
+// Like NewRetryPolicy, this assumes the Source redelivers a Nack'd record as
+// the very next Receive (the sequential S2 model), so a consecutive-hit counter
+// over the last-seen fingerprint suffices. A Source that interleaves other
+// records before redelivering would reset the key each time and escape pacing.
+//
 // This bounds poison-record read amplification at the source: on S2 every
 // redelivery reopens a streaming read session at the stalled cursor and the
 // server re-pushes the backlog behind it, so unpaced retries of a permanently

--- a/events/inbox/backoff.go
+++ b/events/inbox/backoff.go
@@ -30,8 +30,9 @@ func (b *redeliveryBackoff) next(key string) time.Duration {
 	switch {
 	case b.delay == 0:
 		b.delay = b.base
-	case b.delay >= b.max/2:
-		// Doubling would overshoot the cap (or overflow the duration).
+	case b.delay > b.max/2:
+		// Doubling would overshoot the cap (or overflow the duration). The strict
+		// comparison lets delay == max/2 double to exactly max.
 		b.delay = b.max
 	default:
 		b.delay *= 2

--- a/events/inbox/backoff_test.go
+++ b/events/inbox/backoff_test.go
@@ -1,0 +1,32 @@
+package inbox
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRedeliveryBackoff_EscalatesPerRecordAndCaps(t *testing.T) {
+	b := redeliveryBackoff{base: 10 * time.Millisecond, max: 40 * time.Millisecond}
+
+	assert.Equal(t, time.Duration(0), b.next("a"), "first redelivery is immediate")
+	assert.Equal(t, 10*time.Millisecond, b.next("a"))
+	assert.Equal(t, 20*time.Millisecond, b.next("a"))
+	assert.Equal(t, 40*time.Millisecond, b.next("a"))
+	assert.Equal(t, 40*time.Millisecond, b.next("a"), "capped at max")
+
+	assert.Equal(t, time.Duration(0), b.next("b"), "a different record restarts the schedule")
+	assert.Equal(t, 10*time.Millisecond, b.next("b"))
+
+	b.reset()
+	assert.Equal(t, time.Duration(0), b.next("b"), "reset clears the escalation")
+}
+
+func TestRedeliveryBackoff_ClampsWhenDoublingOvershootsMax(t *testing.T) {
+	b := redeliveryBackoff{base: 30 * time.Millisecond, max: 40 * time.Millisecond}
+
+	assert.Equal(t, time.Duration(0), b.next("a"))
+	assert.Equal(t, 30*time.Millisecond, b.next("a"))
+	assert.Equal(t, 40*time.Millisecond, b.next("a"), "clamps to max instead of doubling past it")
+}

--- a/events/inbox/deadletter.go
+++ b/events/inbox/deadletter.go
@@ -123,6 +123,16 @@ func payloadFingerprint(payload []byte) string {
 	return hex.EncodeToString(sum[:])
 }
 
+// shortFingerprint abbreviates a payload fingerprint for log lines. The prefix
+// is enough to correlate with a dead-letter row's PayloadHash.
+func shortFingerprint(fp string) string {
+	const n = 12
+	if len(fp) <= n {
+		return fp
+	}
+	return fp[:n]
+}
+
 // sanitizeForText makes a diagnostic string safe for a Postgres text column,
 // which rejects NUL (0x00) and invalid UTF-8. Only the human-readable columns are
 // coerced; the raw record is preserved verbatim in the bytea payload column.

--- a/events/inbox/inbox.go
+++ b/events/inbox/inbox.go
@@ -55,6 +55,18 @@ type Delivery struct {
 	Payload []byte
 	Ack     func() error
 	Nack    func() error
+
+	// fp memoizes fingerprint(); a failing record's fingerprint is needed by both
+	// the retry policy and the redelivery backoff.
+	fp string
+}
+
+// fingerprint returns payloadFingerprint(Payload), computed once per Delivery.
+func (d *Delivery) fingerprint() string {
+	if d.fp == "" {
+		d.fp = payloadFingerprint(d.Payload)
+	}
+	return d.fp
 }
 
 // Disposition is the error policy's verdict for a failed record.
@@ -205,9 +217,11 @@ func Consume[T proto.Message](ctx context.Context, source Source, newEvent func(
 
 		// The record was not acked and redelivers as the very next Receive. Pace
 		// consecutive redeliveries of the same record so a poison record cannot
-		// spin the reopen loop at full speed.
-		if delay := backoff.next(payloadFingerprint(d.Payload)); delay > 0 {
-			log.Debugf("inbox: pacing redelivery by %s", delay)
+		// spin the reopen loop at full speed. Warn (not debug) so an operator can
+		// see the backoff is engaged and at what delay without redeploying; the
+		// fingerprint prefix correlates with the dead-letter row's PayloadHash.
+		if delay := backoff.next(d.fingerprint()); delay > 0 {
+			log.Warnf("inbox: pacing redelivery of record %s by %s", shortFingerprint(d.fingerprint()), delay)
 			if !sleepCtx(ctx, delay) {
 				return ctx.Err()
 			}

--- a/events/inbox/inbox.go
+++ b/events/inbox/inbox.go
@@ -25,6 +25,13 @@ import (
 // transient transport error from Source.Receive.
 const defaultRestartDelay = 5 * time.Second
 
+// defaultRedeliveryBase and defaultRedeliveryMax bound the exponential backoff
+// that paces repeated redeliveries of the same record (see redeliveryBackoff).
+const (
+	defaultRedeliveryBase = 1 * time.Second
+	defaultRedeliveryMax  = 60 * time.Second
+)
+
 // Handler processes one decoded event plus its envelope. It is called in stream
 // order with no concurrency. A non-nil error is routed through the error policy
 // (see Disposition / WithErrorHandler); it does not advance the cursor.
@@ -79,9 +86,11 @@ type Dedup interface {
 }
 
 type config struct {
-	errorHandler ErrorHandler
-	dedup        Dedup
-	restartDelay time.Duration
+	errorHandler   ErrorHandler
+	dedup          Dedup
+	restartDelay   time.Duration
+	redeliveryBase time.Duration
+	redeliveryMax  time.Duration
 }
 
 // Option configures Consume.
@@ -109,6 +118,23 @@ func WithRestartDelay(d time.Duration) Option {
 	}
 }
 
+// WithRedeliveryBackoff overrides the exponential backoff that paces repeated
+// redeliveries of the same record (default 1s doubling to 60s). The first
+// redelivery is always immediate — the backoff starts on the second consecutive
+// failure of one record, the poison signature. A non-positive base is ignored;
+// a max below base is raised to base.
+func WithRedeliveryBackoff(base, max time.Duration) Option {
+	return func(c *config) {
+		if base <= 0 {
+			return
+		}
+		if max < base {
+			max = base
+		}
+		c.redeliveryBase, c.redeliveryMax = base, max
+	}
+}
+
 // Consume reads the feed via source and processes each record with handler until
 // ctx is done. newEvent constructs a fresh T to decode into (T is a proto pointer
 // type, so it cannot be allocated generically without a constructor).
@@ -117,6 +143,12 @@ func WithRestartDelay(d time.Duration) Option {
 // success, error policy on failure. A transient Receive error backs off and
 // retries (the Source reopens at the persisted cursor); only ctx cancellation
 // returns. This folds every consumer's hand-rolled restart loop into one place.
+//
+// Redeliveries of one failing record are paced with exponential backoff (see
+// WithRedeliveryBackoff): the first retry is immediate, consecutive ones wait
+// base, 2*base, ... up to max. On S2 a redelivery reopens a read session that
+// re-streams the backlog behind the stalled cursor, so an unpaced permanently
+// failing record amplifies into unbounded metered reads.
 func Consume[T proto.Message](ctx context.Context, source Source, newEvent func() T, handler Handler[T], opts ...Option) error {
 	if source == nil {
 		return errors.New("inbox: source is required")
@@ -135,10 +167,16 @@ func Consume[T proto.Message](ctx context.Context, source Source, newEvent func(
 		return errors.New("inbox: newEvent must return a non-nil message")
 	}
 
-	cfg := config{restartDelay: defaultRestartDelay}
+	cfg := config{
+		restartDelay:   defaultRestartDelay,
+		redeliveryBase: defaultRedeliveryBase,
+		redeliveryMax:  defaultRedeliveryMax,
+	}
 	for _, o := range opts {
 		o(&cfg)
 	}
+
+	backoff := redeliveryBackoff{base: cfg.redeliveryBase, max: cfg.redeliveryMax}
 
 	for {
 		if err := ctx.Err(); err != nil {
@@ -160,42 +198,52 @@ func Consume[T proto.Message](ctx context.Context, source Source, newEvent func(
 			continue
 		}
 
-		handleOne(ctx, d, newEvent, handler, cfg)
+		if !handleOne(ctx, d, newEvent, handler, cfg) {
+			backoff.reset()
+			continue
+		}
+
+		// The record was not acked and redelivers as the very next Receive. Pace
+		// consecutive redeliveries of the same record so a poison record cannot
+		// spin the reopen loop at full speed.
+		if delay := backoff.next(payloadFingerprint(d.Payload)); delay > 0 {
+			log.Debugf("inbox: pacing redelivery by %s", delay)
+			if !sleepCtx(ctx, delay) {
+				return ctx.Err()
+			}
+		}
 	}
 }
 
 // handleOne decodes, optionally dedups, runs the handler, and commits. Every
-// record-level error is absorbed via the error policy (Retry/Skip), so it returns
-// nothing: the loop always proceeds to the next Receive.
-func handleOne[T proto.Message](ctx context.Context, d *Delivery, newEvent func() T, handler Handler[T], cfg config) {
+// record-level error is absorbed via the error policy (Retry/Skip). It reports
+// whether the record was left un-acked — i.e. it redelivers on the next Receive
+// — so the loop can pace the redelivery.
+func handleOne[T proto.Message](ctx context.Context, d *Delivery, newEvent func() T, handler Handler[T], cfg config) bool {
 	event := newEvent()
 	if err := proto.Unmarshal(d.Payload, event); err != nil {
-		dispose(ctx, d, fmt.Errorf("decode: %w", err), cfg)
-		return
+		return dispose(ctx, d, fmt.Errorf("decode: %w", err), cfg)
 	}
 
 	meta, err := events.MetaOf(event)
 	if err != nil {
-		dispose(ctx, d, fmt.Errorf("envelope: %w", err), cfg)
-		return
+		return dispose(ctx, d, fmt.Errorf("envelope: %w", err), cfg)
 	}
 
 	eventID := meta.GetEventId()
 	if cfg.dedup != nil && eventID != "" {
 		seen, err := cfg.dedup.Seen(ctx, eventID)
 		if err != nil {
-			dispose(ctx, d, fmt.Errorf("dedup check: %w", err), cfg)
-			return
+			return dispose(ctx, d, fmt.Errorf("dedup check: %w", err), cfg)
 		}
 		if seen {
-			ackQuietly(d) // already processed: advance without re-running the handler
-			return
+			// Already processed: advance without re-running the handler.
+			return !ackQuietly(d)
 		}
 	}
 
 	if err := handler(ctx, event, meta); err != nil {
-		dispose(ctx, d, fmt.Errorf("handler: %w", err), cfg)
-		return
+		return dispose(ctx, d, fmt.Errorf("handler: %w", err), cfg)
 	}
 
 	if cfg.dedup != nil && eventID != "" {
@@ -207,17 +255,13 @@ func handleOne[T proto.Message](ctx context.Context, d *Delivery, newEvent func(
 		}
 	}
 
-	if err := d.Ack(); err != nil {
-		// Ack failure = non-advance: the cursor never leads the handler, so the
-		// record redelivers on the next read and idempotency absorbs it. The Source
-		// owns the reopen; here we just log and move on.
-		log.Warnf("inbox: ack failed (record will be redelivered): %v", err)
-	}
+	return !ackQuietly(d)
 }
 
 // dispose applies the error policy to a failed record: Retry (Nack/redeliver) by
-// default, or whatever a configured ErrorHandler decides.
-func dispose(ctx context.Context, d *Delivery, cause error, cfg config) {
+// default, or whatever a configured ErrorHandler decides. It reports whether the
+// record redelivers.
+func dispose(ctx context.Context, d *Delivery, cause error, cfg config) bool {
 	disposition := Retry
 	if cfg.errorHandler != nil {
 		disposition = cfg.errorHandler(ctx, d, cause)
@@ -226,22 +270,29 @@ func dispose(ctx context.Context, d *Delivery, cause error, cfg config) {
 	switch disposition {
 	case Skip:
 		log.Warnf("inbox: skipping record after error: %v", cause)
-		ackQuietly(d)
+		return !ackQuietly(d)
 	default:
 		// Retry: redeliver. On S2 this reopens at the cursor and re-reads the same
-		// record; a permanently-failing record blocks the feed until an operator
-		// wires WithErrorHandler->Skip (the Source emits a stalled-cursor warning).
+		// record; a permanently-failing record blocks the feed — paced by the
+		// redelivery backoff — until dead-lettered or skipped (the Source emits a
+		// stalled-cursor warning).
 		log.Warnf("inbox: redelivering record after error: %v", cause)
 		if err := d.Nack(); err != nil {
 			log.Warnf("inbox: nack failed: %v", err)
 		}
+		return true
 	}
 }
 
-func ackQuietly(d *Delivery) {
+// ackQuietly acks the record, reporting whether the ack succeeded. An ack
+// failure is a non-advance: the record redelivers on the next read and handler
+// idempotency absorbs it.
+func ackQuietly(d *Delivery) bool {
 	if err := d.Ack(); err != nil {
 		log.Warnf("inbox: ack failed (record will be redelivered): %v", err)
+		return false
 	}
+	return true
 }
 
 // nilMessage reports whether a constructed event is a nil pointer (or boxed nil),

--- a/events/inbox/inbox_test.go
+++ b/events/inbox/inbox_test.go
@@ -69,7 +69,7 @@ type fakeDedup struct{ marked map[string]bool }
 func newFakeDedup() *fakeDedup { return &fakeDedup{marked: map[string]bool{}} }
 
 func (f *fakeDedup) Seen(_ context.Context, id string) (bool, error) { return f.marked[id], nil }
-func (f *fakeDedup) Mark(_ context.Context, id string) error        { f.marked[id] = true; return nil }
+func (f *fakeDedup) Mark(_ context.Context, id string) error         { f.marked[id] = true; return nil }
 
 func TestConsume_HandleThenAck(t *testing.T) {
 	src := &fakeSource{steps: []step{
@@ -184,6 +184,27 @@ func TestConsume_DedupSkipsDuplicateEventID(t *testing.T) {
 	assert.ErrorIs(t, err, context.Canceled)
 	assert.Equal(t, 1, calls, "duplicate event_id must not re-run the handler")
 	assert.Equal(t, 2, src.acks, "both the original and the skipped duplicate advance")
+}
+
+func TestConsume_RedeliveryBackoffPacesRepeatedFailures(t *testing.T) {
+	// The same record failing three times: the first redelivery is immediate,
+	// the next two wait 20ms and 40ms. Only the lower bound is asserted — timers
+	// never fire early, so this cannot flake on a slow machine.
+	payload := eventBytes(t, "evt-poison")
+	src := &fakeSource{steps: []step{{payload: payload}, {payload: payload}, {payload: payload}}}
+
+	handler := func(_ context.Context, _ *pkgregv1.PackageVersionObservationEvent, _ *commonv1.EventMeta) error {
+		return errors.New("boom")
+	}
+
+	start := time.Now()
+	err := inbox.Consume(t.Context(), src, newObservation, handler,
+		inbox.WithRedeliveryBackoff(20*time.Millisecond, 80*time.Millisecond))
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 3, src.nacks)
+	assert.GreaterOrEqual(t, elapsed, 60*time.Millisecond, "second and third redeliveries are paced")
 }
 
 func TestConsume_Validation(t *testing.T) {

--- a/events/inbox/inbox_test.go
+++ b/events/inbox/inbox_test.go
@@ -207,6 +207,36 @@ func TestConsume_RedeliveryBackoffPacesRepeatedFailures(t *testing.T) {
 	assert.GreaterOrEqual(t, elapsed, 60*time.Millisecond, "second and third redeliveries are paced")
 }
 
+func TestConsume_AckFailurePacesRedelivery(t *testing.T) {
+	// The handler succeeds but the ack (cursor advance) fails, so the record
+	// redelivers: the same pacing must apply, or a cursor-store outage spins the
+	// tight reopen cycle a poison record does. Three deliveries of one record
+	// sleep 0, 20ms and 40ms; only the lower bound is asserted.
+	payload := eventBytes(t, "evt-ack-fail")
+	src := &fakeSource{steps: []step{
+		{payload: payload, ackErr: errors.New("cursor store down")},
+		{payload: payload, ackErr: errors.New("cursor store down")},
+		{payload: payload, ackErr: errors.New("cursor store down")},
+	}}
+
+	calls := 0
+	handler := func(_ context.Context, _ *pkgregv1.PackageVersionObservationEvent, _ *commonv1.EventMeta) error {
+		calls++
+		return nil
+	}
+
+	start := time.Now()
+	err := inbox.Consume(t.Context(), src, newObservation, handler,
+		inbox.WithRedeliveryBackoff(20*time.Millisecond, 80*time.Millisecond))
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 3, calls, "the handler re-runs on each redelivery")
+	assert.Equal(t, 3, src.acks, "each attempt tries to ack")
+	assert.Equal(t, 0, src.nacks, "an ack failure is not a Nack")
+	assert.GreaterOrEqual(t, elapsed, 60*time.Millisecond, "ack-failure redeliveries are paced")
+}
+
 func TestConsume_Validation(t *testing.T) {
 	handler := func(_ context.Context, _ *pkgregv1.PackageVersionObservationEvent, _ *commonv1.EventMeta) error {
 		return nil

--- a/events/inbox/retry.go
+++ b/events/inbox/retry.go
@@ -74,7 +74,7 @@ func NewRetryPolicy(dlq DeadLetterQueue, opts ...RetryOption) ErrorHandler {
 	)
 
 	return func(ctx context.Context, d *Delivery, cause error) Disposition {
-		key := payloadFingerprint(d.Payload)
+		key := d.fingerprint()
 		if key == lastKey {
 			attempts++
 		} else {

--- a/events/inbox/retry_test.go
+++ b/events/inbox/retry_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	commonv1 "buf.build/gen/go/safedep/api/protocolbuffers/go/safedep/events/common/v1"
 	pkgregv1 "buf.build/gen/go/safedep/api/protocolbuffers/go/safedep/events/private/packageregistry/v1"
@@ -151,6 +152,7 @@ func TestConsume_RetryPolicyDeadLettersPoisonRecord(t *testing.T) {
 	dlq := &fakeDLQ{}
 	err := inbox.Consume(t.Context(), src, newObservation, handler,
 		inbox.WithErrorHandler(inbox.NewRetryPolicy(dlq, inbox.WithMaxAttempts(3))),
+		inbox.WithRedeliveryBackoff(time.Millisecond, 2*time.Millisecond),
 	)
 	require.ErrorIs(t, err, context.Canceled)
 


### PR DESCRIPTION
## Problem

A record that fails its handler is Nack'd and redelivered as the **very next** `Receive` with zero delay — `Consume`'s `restartDelay` only paces transport errors, not handler failures. On S2 each redelivery reopens a streaming read session at the stalled cursor and the server re-pushes the backlog behind it before the client tears the session down, so a permanently failing (poison) record spins the reopen loop at full speed.

This is the amplifier behind the 2026-08-07 S2 read spike: a NUL-byte poison record (safedep/malysis#552) held one consumer in this loop at ~4–5 reopens/sec — ~350k metered read ops and ~87 GB of read throughput in a single day, growing as the backlog behind the stuck cursor grew.

The bounded-retry DLQ (#145) caps how many times one record retries, but the attempts still fire back-to-back: a brief DB blip could burn the whole budget in milliseconds and dead-letter records that would have succeeded a second later. And a consumer without a DLQ wired still loops forever, unpaced.

## Fix

Pace redeliveries in the `Consume` core so every `Source` benefits:

- **First redelivery stays immediate** — a one-off transient failure costs no added latency. The backoff starts on the second consecutive failure of the *same record* (the poison signature), then doubles: base, 2×base, … capped at max. Defaults 1s → 60s, tunable via `WithRedeliveryBackoff(base, max)`.
- **The record is identified by its payload fingerprint** (same helper the retry policy uses), so a different record failing next resets the schedule instead of inheriting the delay.
- **Ack failures are paced too.** `handleOne` now reports whether the record was left un-acked for any reason — handler error, decode error, or a failed cursor advance — and the loop paces all of them. A cursor-store outage previously spun the same tight reopen cycle.
- The sleep is context-aware (`sleepCtx`), so shutdown is never delayed.

With the DLQ's default 4-attempt budget, the retries of one poison record now span ~7s (1s + 2s + 4s) instead of milliseconds — transient blips get a real window to clear. Without a DLQ, a stuck record costs at most one reopen per minute (~1.4k reads/day) instead of ~350k.

No exported API changes beyond the new option; consumers pick this up with a plain pin bump.

## Changes

- `events/inbox/backoff.go`: `redeliveryBackoff` — per-record escalation state (immediate → base → 2×base → … → max), overshoot-safe cap
- `events/inbox/inbox.go`: `WithRedeliveryBackoff` option + defaults; `handleOne`/`dispose`/`ackQuietly` report redelivery; `Consume` paces before the next `Receive`
- Tests: backoff state machine (escalate / cap / reset / new-record), Consume-level pacing (lower-bound timing, cannot flake early), DLQ e2e pinned to fast backoff values

## Testing

- `go test ./events/inbox/... -count=1` — all pass (new + existing)
- `go vet ./events/...`, `gofmt` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018CV4TtHjkEBZysifegKg4z

---
_Generated by [Claude Code](https://claude.ai/code/session_018CV4TtHjkEBZysifegKg4z)_